### PR TITLE
Move return types to 64bit arrays

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -38,7 +38,7 @@ impl HighwayHash for HighwayBuilder {
         }
     }
 
-    fn hash128(self, data: &[u8]) -> u128 {
+    fn hash128(self, data: &[u8]) -> [u64; 2] {
         match self.0 {
             HighwayChoices::Portable(x) => x.hash128(data),
             #[cfg(target_arch = "x86_64")]
@@ -48,7 +48,7 @@ impl HighwayHash for HighwayBuilder {
         }
     }
 
-    fn hash256(self, data: &[u8]) -> (u128, u128) {
+    fn hash256(self, data: &[u8]) -> [u64; 4] {
         match self.0 {
             HighwayChoices::Portable(x) => x.hash256(data),
             #[cfg(target_arch = "x86_64")]
@@ -78,7 +78,7 @@ impl HighwayHash for HighwayBuilder {
         }
     }
 
-    fn finalize128(self) -> u128 {
+    fn finalize128(self) -> [u64; 2] {
         match self.0 {
             HighwayChoices::Portable(x) => x.finalize128(),
             #[cfg(target_arch = "x86_64")]
@@ -88,7 +88,7 @@ impl HighwayHash for HighwayBuilder {
         }
     }
 
-    fn finalize256(self) -> (u128, u128) {
+    fn finalize256(self) -> [u64; 4] {
         match self.0 {
             HighwayChoices::Portable(x) => x.finalize256(),
             #[cfg(target_arch = "x86_64")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,16 +43,21 @@
 //! let key = Key([1, 2, 3, 4]);
 //! let mut hasher128 = HighwayBuilder::new(&key);
 //! hasher128.append(&[255]);
-//! let res128: u128 = hasher128.finalize128();
-//! assert_eq!(0x224508f9_16b3991f_bb007d24_62e77f3c, res128);
+//! let res128: [u64; 2] = hasher128.finalize128();
+//! assert_eq!([0xbb007d2462e77f3c, 0x224508f916b3991f], res128);
 //!
 //! // Generate 256bit hash
 //! let key = Key([1, 2, 3, 4]);
 //! let mut hasher256 = HighwayBuilder::new(&key);
 //! hasher256.append(&[255]);
-//! let (res256lo, res256hi): (u128, u128) = hasher256.finalize256();
-//! assert_eq!(0xaac4905d_e62b2f5e_7161cadb_f7cd70e1, res256lo);
-//! assert_eq!(0xc8efcfc4_5b239f8d_07b02b93_6933faa7, res256hi);
+//! let res256: [u64; 4] = hasher256.finalize256();
+//! let expected: [u64; 4] = [
+//!     0x7161cadbf7cd70e1,
+//!     0xaac4905de62b2f5e,
+//!     0x7b02b936933faa7,
+//!     0xc8efcfc45b239f8d,
+//! ];
+//! assert_eq!(expected, res256);
 //! ```
 //!
 //! ## Use Cases

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -7,11 +7,11 @@ pub trait HighwayHash {
 
     /// Convenience function for hashing all data in a single call and receiving a 128bit hash.
     /// Results are equivalent to appending the data manually.
-    fn hash128(self, data: &[u8]) -> u128;
+    fn hash128(self, data: &[u8]) -> [u64; 2];
 
     /// Convenience function for hashing all data in a single call and receiving a 256bit hash.
     /// Results are equivalent to appending the data manually.
-    fn hash256(self, data: &[u8]) -> (u128, u128);
+    fn hash256(self, data: &[u8]) -> [u64; 4];
 
     /// Adds data to be hashed. If it is important, the performance characteristics of this
     /// function differs depending on the amount of data previously hashed and the amount of
@@ -23,8 +23,8 @@ pub trait HighwayHash {
     fn finalize64(self) -> u64;
 
     /// Consumes the hasher to return the 128bit hash
-    fn finalize128(self) -> u128;
+    fn finalize128(self) -> [u64; 2];
 
     /// Consumes the hasher to return the 256bit hash
-    fn finalize256(self) -> (u128, u128);
+    fn finalize256(self) -> [u64; 4];
 }

--- a/tests/highway-test.rs
+++ b/tests/highway-test.rs
@@ -445,9 +445,11 @@ fn portable_hash_all() {
 
     for i in 0..64 {
         println!("{}", i);
+        let res_128 = u64_to_u128(&PortableHash::new(&key).hash128(&data[..i])[..]);
+        let res_256 = u64_to_u256(&PortableHash::new(&key).hash256(&data[..i])[..]);
         assert_eq!(expected64[i], PortableHash::new(&key).hash64(&data[..i]));
-        assert_eq!(expected128[i], PortableHash::new(&key).hash128(&data[..i]));
-        assert_eq!(expected256[i], PortableHash::new(&key).hash256(&data[..i]));
+        assert_eq!(expected128[i], res_128);
+        assert_eq!(expected256[i], res_256);
 
         assert_eq!(expected64[i], {
             let mut hasher = PortableHash::new(&key);
@@ -457,14 +459,22 @@ fn portable_hash_all() {
         assert_eq!(expected128[i], {
             let mut hasher = PortableHash::new(&key);
             hasher.append(&data[..i]);
-            hasher.finalize128()
+            u64_to_u128(&hasher.finalize128()[..])
         });
         assert_eq!(expected256[i], {
             let mut hasher = PortableHash::new(&key);
             hasher.append(&data[..i]);
-            hasher.finalize256()
+            u64_to_u256(&hasher.finalize256()[..])
         });
     }
+}
+
+fn u64_to_u128(data: &[u64]) -> u128 {
+    u128::from(data[0]) + (u128::from(data[1]) << 64)
+}
+
+fn u64_to_u256(data: &[u64]) -> (u128, u128) {
+    (u64_to_u128(data), u64_to_u128(&data[2..]))
 }
 
 #[cfg(target_arch = "x86_64")]


### PR DESCRIPTION
Thus staying consistent with the official cpp return types. It uses
[u64; 2] and [u64; 4] instead of u128 and (u128, u128) respectively

Closes https://github.com/nickbabcock/highway-rs/issues/9