### PR TITLE
Compatibility with std Hasher

### DIFF
--- a/src/avx.rs
+++ b/src/avx.rs
@@ -9,7 +9,7 @@ use v4x64u::V4x64U;
 
 /// AVX empowered implementation that will only work on `x86_64` with avx2 enabled at the CPU
 /// level.
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct AvxHash {
     key: Key,
     buffer: HashPacket,

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,13 +1,14 @@
 use key::Key;
 use portable::PortableHash;
 use traits::HighwayHash;
+use std::default::Default;
 
 #[cfg(target_arch = "x86_64")]
 use avx::AvxHash;
 #[cfg(target_arch = "x86_64")]
 use sse::SseHash;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 enum HighwayChoices {
     Portable(PortableHash),
     #[cfg(target_arch = "x86_64")]
@@ -24,7 +25,7 @@ enum HighwayChoices {
 ///  - AvxHash
 ///  - SseHash
 ///  - PortableHash
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct HighwayBuilder(HighwayChoices);
 
 impl HighwayHash for HighwayBuilder {
@@ -114,5 +115,11 @@ impl HighwayBuilder {
         }
 
         HighwayBuilder(HighwayChoices::Portable(PortableHash::new(key)))
+    }
+}
+
+impl Default for HighwayBuilder {
+    fn default() -> Self {
+        HighwayBuilder::new(&Key::default())
     }
 }

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -1,0 +1,55 @@
+use std::hash::{Hasher, BuildHasher};
+use key::Key;
+use builder::HighwayBuilder;
+use traits::HighwayHash;
+
+#[derive(Debug, Default)]
+pub struct HighwayHasher {
+    builder: HighwayBuilder
+}
+
+impl HighwayHasher {
+    pub fn new(key: &Key) -> Self {
+        HighwayHasher {
+            builder: HighwayBuilder::new(key)
+        }
+    }
+}
+
+impl Hasher for HighwayHasher {
+    fn write(&mut self, bytes: &[u8]) {
+        self.builder.append(bytes);
+    }
+
+    fn finish(&self) -> u64 {
+        // Reasons why we need to clone. finalize64` mutates internal state so either we need our
+        // Hasher to consume itself or receive a mutable reference on `finish`. We receive neither,
+        // due to finish being a misnomer (additional writes could be expected) and it's intended
+        // for the hasher to merely return it's current state. The issue with HighwayHash is that
+        // there are several rounds of permutations when finalizing a value, and internal state is
+        // modified during that process. We work around these constraints by cloning the hasher and
+        // finalizing that one.
+        self.builder.clone().finalize64()
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct HighwayBuildHasher {
+    key: Key
+}
+
+impl HighwayBuildHasher {
+    pub fn new(key: Key) -> Self {
+        HighwayBuildHasher {
+            key
+        }
+    }
+}
+
+impl BuildHasher for HighwayBuildHasher {
+    type Hasher = HighwayHasher;
+
+    fn build_hasher(&self) -> Self::Hasher {
+        HighwayHasher::new(&self.key)
+    }
+}

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -23,7 +23,7 @@ pub const PACKET_SIZE: usize = 32;
 /// to simd instructions, so we need to subscribe to the whole "do what C does", else we will
 /// segfault.
 #[repr(C)]
-#[derive(Default, Debug)]
+#[derive(Default, Debug, Clone, Copy)]
 pub struct HashPacket {
     buf: [u8; PACKET_SIZE],
     buf_index: usize,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,6 +60,36 @@
 //! assert_eq!(expected, res256);
 //! ```
 //!
+//! Use highway hash in standard rust collections
+//!
+//! ```
+//! use std::collections::HashMap;
+//! use highway::{HighwayBuildHasher, Key};
+//! let mut map =
+//!   HashMap::with_hasher(HighwayBuildHasher::new(Key([
+//!     0xcbf29ce484222325,
+//!     0xc3a5c85c97cb3127,
+//!     0xb492b66fbe98f273,
+//!     0x9ae16a3b2f90404f,
+//!   ])));
+//!
+//! map.insert(1, 2);
+//! assert_eq!(map.get(&1), Some(&2));
+//! ```
+//!
+//! Or if utilizing a key is not important, one can use the default
+//!
+//! ```
+//! use std::collections::HashMap;
+//! use std::hash::BuildHasherDefault;
+//! use highway::HighwayHasher;
+//! let mut map =
+//!   HashMap::with_hasher(BuildHasherDefault::<HighwayHasher>::default());
+//!
+//! map.insert(1, 2);
+//! assert_eq!(map.get(&1), Some(&2));
+//! ```
+//!
 //! ## Use Cases
 //!
 //! HighwayHash can be used against untrusted user input where weak hashes can't be used due to exploitation, verified cryptographic hashes are too slow, and a strong hash function meets requirements. Some specific scenarios given by the authors of HighwayHash:
@@ -78,11 +108,13 @@ mod internal;
 mod key;
 mod portable;
 mod traits;
+mod hash;
 
 pub use builder::HighwayBuilder;
 pub use key::Key;
 pub use portable::PortableHash;
 pub use traits::HighwayHash;
+pub use hash::{HighwayBuildHasher, HighwayHasher};
 
 #[cfg(target_arch = "x86_64")]
 mod avx;

--- a/src/portable.rs
+++ b/src/portable.rs
@@ -4,7 +4,7 @@ use key::Key;
 use traits::HighwayHash;
 
 /// Portable HighwayHash implementation. Will run on any platform Rust will run on.
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct PortableHash {
     key: Key,
     buffer: HashPacket,

--- a/src/sse.rs
+++ b/src/sse.rs
@@ -8,7 +8,7 @@ use v2x64u::V2x64U;
 
 /// SSE empowered implementation that will only work on `x86_64` with sse 4.1 enabled at the CPU
 /// level.
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct SseHash {
     key: Key,
     buffer: HashPacket,


### PR DESCRIPTION
- Provide implementations to use Highway in HashMap, etc.
- Added clone implementations to many structures
- impl Default for HighwayBuilder 

Example

Use highway hash in standard rust collections

```rust
use std::collections::HashMap;
use highway::{HighwayBuildHasher, Key};
let mut map =
  HashMap::with_hasher(HighwayBuildHasher::new(Key([
    0xcbf29ce484222325,
    0xc3a5c85c97cb3127,
    0xb492b66fbe98f273,
    0x9ae16a3b2f90404f,
  ])));

map.insert(1, 2);
assert_eq!(map.get(&1), Some(&2));
```

Or if utilizing a key is not important, one can use the default

```rust
use std::collections::HashMap;
use std::hash::BuildHasherDefault;
use highway::HighwayHasher;
let mut map =
  HashMap::with_hasher(BuildHasherDefault::<HighwayHasher>::default());

map.insert(1, 2);
assert_eq!(map.get(&1), Some(&2));
```