### PR TITLE
Update fuzz suite

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,9 @@ keywords = ["HighwayHash", "hash", "simd", "avx"]
 [dependencies]
 byteorder = "1"
 
+# Used for fuzzing
+arbitrary = { version = "0.3.0", optional = true, features = ["derive"] }
+
 [dev-dependencies]
 criterion = "0.3.0"
 sha2 = "0.8.0"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -3,6 +3,7 @@
 name = "highway-fuzz"
 version = "0.0.1"
 authors = ["Automatically generated"]
+edition = "2018"
 publish = false
 
 [package.metadata]
@@ -10,11 +11,11 @@ cargo-fuzz = true
 
 [dependencies.highway]
 path = ".."
-[dependencies.libfuzzer-sys]
-git = "https://github.com/rust-fuzz/libfuzzer-sys.git"
+features = ["arbitrary"]
 
 [dependencies]
-byteorder = "1"
+libfuzzer-sys = "0.2.1"
+arbitrary = { version = "0.3", features = ["derive"] }
 
 # Prevent this from interfering with workspaces
 [workspace]

--- a/fuzz/fuzz_targets/common.rs
+++ b/fuzz/fuzz_targets/common.rs
@@ -1,18 +1,7 @@
-use byteorder::{ByteOrder, LE};
 use highway::Key;
 
-pub fn split_with_key(data: &[u8]) -> (Key, &[u8]) {
-    let mut key_data = [0u8; 32];
-    let mut rd: &[u8] = &[];
-    if data.len() >= 32 {
-        key_data.copy_from_slice(&data[..32]);
-        rd = &data[32..];
-    } else {
-        key_data[..data.len()].copy_from_slice(&data[..data.len()]);
-    }
-
-    let mut true_key = [0u64; 4];
-    LE::read_u64_into(&key_data, &mut true_key);
-    let key = Key(true_key);
-    (key, rd)
+#[derive(Debug, arbitrary::Arbitrary)]
+pub struct FuzzKey {
+    pub key: Key,
+    pub data: Vec<u8>,
 }

--- a/fuzz/fuzz_targets/fuzz_avx.rs
+++ b/fuzz/fuzz_targets/fuzz_avx.rs
@@ -1,20 +1,17 @@
 #![no_main]
-#[macro_use]
-extern crate libfuzzer_sys;
-extern crate highway;
-extern crate byteorder;
 
 mod common;
 use highway::{AvxHash, HighwayHash};
 
 #[cfg(target_arch = "x86_64")]
-fuzz_target!(|data: &[u8]| {
+libfuzzer_sys::fuzz_target!(|input: common::FuzzKey| {
+    let (key, data) = &(input.key, input.data);
+
     if !is_x86_feature_detected!("avx2") {
         panic!("avx2 is not supported");
     }
 
     unsafe {
-        let (key, data) = common::split_with_key(data);
         let hash1 = AvxHash::force_new(&key).hash64(data);
         let hash2 = AvxHash::force_new(&key).hash64(data);
         assert_eq!(hash1, hash2);

--- a/fuzz/fuzz_targets/fuzz_portable.rs
+++ b/fuzz/fuzz_targets/fuzz_portable.rs
@@ -1,14 +1,10 @@
 #![no_main]
-#[macro_use]
-extern crate libfuzzer_sys;
-extern crate highway;
-extern crate byteorder;
 
 mod common;
 use highway::{HighwayHash, PortableHash};
 
-fuzz_target!(|data: &[u8]| {
-    let (key, data) = common::split_with_key(data);
+libfuzzer_sys::fuzz_target!(|input: common::FuzzKey| {
+    let (key, data) = &(input.key, input.data);
     let hash1 = PortableHash::new(&key).hash64(data);
     let hash2 = PortableHash::new(&key).hash64(data);
     assert_eq!(hash1, hash2);

--- a/fuzz/fuzz_targets/fuzz_sse.rs
+++ b/fuzz/fuzz_targets/fuzz_sse.rs
@@ -1,20 +1,17 @@
 #![no_main]
-#[macro_use]
-extern crate libfuzzer_sys;
-extern crate highway;
-extern crate byteorder;
 
 mod common;
 use highway::{HighwayHash, SseHash};
 
 #[cfg(target_arch = "x86_64")]
-fuzz_target!(|data: &[u8]| {
+libfuzzer_sys::fuzz_target!(|input: common::FuzzKey| {
+    let (key, data) = &(input.key, input.data);
+
     if !is_x86_feature_detected!("sse4.1") {
         panic!("sse4.1 is not supported");
     }
 
     unsafe {
-        let (key, data) = common::split_with_key(data);
         let hash1 = SseHash::force_new(&key).hash64(data);
         let hash2 = SseHash::force_new(&key).hash64(data);
         assert_eq!(hash1, hash2);

--- a/src/key.rs
+++ b/src/key.rs
@@ -2,6 +2,7 @@ use std::ops::Index;
 
 /// Key used in HighwayHash that will drastically change the hash outputs.
 #[derive(Debug, Default, Clone, Copy)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[repr(align(32))]
 pub struct Key(pub [u64; 4]);
 


### PR DESCRIPTION
- Use official released version of libfuzzer-sys
- Use 2018 edition for rust
- Use the new arbitrary trait to derive key + data from bytes