### PR TITLE
Remove byteorder dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,6 @@ keywords = ["HighwayHash", "hash", "simd", "avx"]
 edition = "2018"
 
 [dependencies]
-byteorder = "1"
-
 # Used for fuzzing
 arbitrary = { version = "0.4.0", optional = true, features = ["derive"] }
 

--- a/src/avx.rs
+++ b/src/avx.rs
@@ -4,7 +4,6 @@ use crate::key::Key;
 use crate::traits::HighwayHash;
 use crate::v2x64u::V2x64U;
 use crate::v4x64u::V4x64U;
-use byteorder::{ByteOrder, LE};
 use std::arch::x86_64::*;
 
 /// AVX empowered implementation that will only work on `x86_64` with avx2 enabled at the CPU
@@ -179,7 +178,7 @@ impl AvxHash {
             let int_mask = _mm_cmpgt_epi32(size, _mm_set_epi32(31, 27, 23, 19));
             let int_lanes = _mm_maskload_epi32(bytes.as_ptr().offset(16) as *const i32, int_mask);
             let remainder = &bytes[(size_mod32 & !3) + size_mod4 - 4..];
-            let last4 = LE::read_i32(remainder);
+            let last4 = i32::from_le_bytes([remainder[0], remainder[1], remainder[2], remainder[3]]);
             let packetH = _mm_insert_epi32(int_lanes, last4, 3);
             let packetL256 = _mm256_castsi128_si256(packetL);
             let packet = _mm256_inserti128_si256(packetL256, packetH, 1);

--- a/src/portable.rs
+++ b/src/portable.rs
@@ -1,7 +1,6 @@
 use crate::internal::{Filled, HashPacket, PACKET_SIZE};
 use crate::key::Key;
 use crate::traits::HighwayHash;
-use byteorder::{ByteOrder, LE};
 
 /// Portable HighwayHash implementation. Will run on any platform Rust will run on.
 #[derive(Debug, Default, Clone)]
@@ -199,11 +198,15 @@ impl PortableHash {
     }
 
     fn to_lanes(packet: &[u8]) -> [u64; 4] {
+        let a = unsafe { &*(packet.as_ptr() as *const [u8; 8]) };
+        let b = unsafe { &*(packet[8..].as_ptr() as *const [u8; 8]) };
+        let c = unsafe { &*(packet[16..].as_ptr() as *const [u8; 8]) };
+        let d = unsafe { &*(packet[24..].as_ptr() as *const [u8; 8]) };
         [
-            LE::read_u64(&packet[0..8]),
-            LE::read_u64(&packet[8..16]),
-            LE::read_u64(&packet[16..24]),
-            LE::read_u64(&packet[24..32]),
+            u64::from_le_bytes([a[0], a[1], a[2], a[3], a[4], a[5], a[6], a[7]]),
+            u64::from_le_bytes([b[0], b[1], b[2], b[3], b[4], b[5], b[6], b[7]]),
+            u64::from_le_bytes([c[0], c[1], c[2], c[3], c[4], c[5], c[6], c[7]]),
+            u64::from_le_bytes([d[0], d[1], d[2], d[3], d[4], d[5], d[6], d[7]]),
         ]
     }
 


### PR DESCRIPTION
Benchmarks for portable and sse showed a bit of an improvement at small payloads.