### PR TITLE
Hashes take an owned key as a parameter

### DIFF
--- a/benches/bench_hashes.rs
+++ b/benches/bench_hashes.rs
@@ -16,7 +16,7 @@ fn builder(c: &mut Criterion) {
         group.bench_with_input(BenchmarkId::from_parameter(size), size, |b, size| {
             let data = vec![0u8; *size];
             let key = Key([0, 0, 0, 0]);
-            b.iter(|| HighwayBuilder::new(&key).hash64(&data));
+            b.iter(|| HighwayBuilder::new(key).hash64(&data));
         });
     }
 
@@ -33,7 +33,7 @@ fn bit64_hash(c: &mut Criterion) {
         group.bench_with_input(BenchmarkId::new("portable", i), i, |b, param| {
             let data = vec![0u8; *param];
             let key = Key([0, 0, 0, 0]);
-            b.iter(|| PortableHash::new(&key).hash64(&data))
+            b.iter(|| PortableHash::new(key).hash64(&data))
         });
 
         group.bench_with_input(BenchmarkId::new("hashmap default", i), i, |b, param| {
@@ -75,19 +75,19 @@ fn bit64_hash(c: &mut Criterion) {
 
         #[cfg(target_arch = "x86_64")]
         {
-            if AvxHash::new(&key).is_some() {
+            if AvxHash::new(key).is_some() {
                 group.bench_with_input(BenchmarkId::new("avx", i), i, |b, param| {
                     let data = vec![0u8; *param];
                     let key = Key([0, 0, 0, 0]);
-                    b.iter(|| unsafe { AvxHash::force_new(&key) }.hash64(&data))
+                    b.iter(|| unsafe { AvxHash::force_new(key) }.hash64(&data))
                 });
             }
 
-            if SseHash::new(&key).is_some() {
+            if SseHash::new(key).is_some() {
                 group.bench_with_input(BenchmarkId::new("sse", i), i, |b, param| {
                     let data = vec![0u8; *param];
                     let key = Key([0, 0, 0, 0]);
-                    b.iter(|| unsafe { SseHash::force_new(&key) }.hash64(&data))
+                    b.iter(|| unsafe { SseHash::force_new(key) }.hash64(&data))
                 });
             }
         }
@@ -105,7 +105,7 @@ fn bit256_hash(c: &mut Criterion) {
         group.bench_with_input(BenchmarkId::new("portable", i), i, |b, param| {
             let data = vec![0u8; *param];
             let key = Key([0, 0, 0, 0]);
-            b.iter(|| PortableHash::new(&key).hash256(&data))
+            b.iter(|| PortableHash::new(key).hash256(&data))
         });
 
         group.bench_with_input(BenchmarkId::new("sha2", i), i, |b, param| {
@@ -136,19 +136,19 @@ fn bit256_hash(c: &mut Criterion) {
 
         #[cfg(target_arch = "x86_64")]
         {
-            if AvxHash::new(&key).is_some() {
+            if AvxHash::new(key).is_some() {
                 group.bench_with_input(BenchmarkId::new("avx", i), i, |b, param| {
                     let data = vec![0u8; *param];
                     let key = Key([0, 0, 0, 0]);
-                    b.iter(|| unsafe { AvxHash::force_new(&key) }.hash256(&data))
+                    b.iter(|| unsafe { AvxHash::force_new(key) }.hash256(&data))
                 });
             }
 
-            if SseHash::new(&key).is_some() {
+            if SseHash::new(key).is_some() {
                 group.bench_with_input(BenchmarkId::new("sse", i), i, |b, param| {
                     let data = vec![0u8; *param];
                     let key = Key([0, 0, 0, 0]);
-                    b.iter(|| unsafe { SseHash::force_new(&key) }.hash256(&data))
+                    b.iter(|| unsafe { SseHash::force_new(key) }.hash256(&data))
                 });
             }
         }

--- a/fuzz/fuzz_targets/fuzz_avx.rs
+++ b/fuzz/fuzz_targets/fuzz_avx.rs
@@ -5,17 +5,17 @@ use highway::{AvxHash, HighwayHash};
 
 #[cfg(target_arch = "x86_64")]
 libfuzzer_sys::fuzz_target!(|input: common::FuzzKey| {
-    let (key, data) = &(input.key, input.data);
+    let (key, data) = (input.key, &input.data);
 
     if !is_x86_feature_detected!("avx2") {
         panic!("avx2 is not supported");
     }
 
     unsafe {
-        let hash1 = AvxHash::force_new(&key).hash64(data);
-        let hash2 = AvxHash::force_new(&key).hash64(data);
+        let hash1 = AvxHash::force_new(key).hash64(data);
+        let hash2 = AvxHash::force_new(key).hash64(data);
         assert_eq!(hash1, hash2);
-        AvxHash::force_new(&key).hash128(data);
-        AvxHash::force_new(&key).hash256(data);
+        AvxHash::force_new(key).hash128(data);
+        AvxHash::force_new(key).hash256(data);
     }
 });

--- a/fuzz/fuzz_targets/fuzz_portable.rs
+++ b/fuzz/fuzz_targets/fuzz_portable.rs
@@ -4,10 +4,10 @@ mod common;
 use highway::{HighwayHash, PortableHash};
 
 libfuzzer_sys::fuzz_target!(|input: common::FuzzKey| {
-    let (key, data) = &(input.key, input.data);
-    let hash1 = PortableHash::new(&key).hash64(data);
-    let hash2 = PortableHash::new(&key).hash64(data);
+    let (key, data) = (input.key, &input.data);
+    let hash1 = PortableHash::new(key).hash64(data);
+    let hash2 = PortableHash::new(key).hash64(data);
     assert_eq!(hash1, hash2);
-    PortableHash::new(&key).hash128(data);
-    PortableHash::new(&key).hash256(data);
+    PortableHash::new(key).hash128(data);
+    PortableHash::new(key).hash256(data);
 });

--- a/fuzz/fuzz_targets/fuzz_sse.rs
+++ b/fuzz/fuzz_targets/fuzz_sse.rs
@@ -5,17 +5,17 @@ use highway::{HighwayHash, SseHash};
 
 #[cfg(target_arch = "x86_64")]
 libfuzzer_sys::fuzz_target!(|input: common::FuzzKey| {
-    let (key, data) = &(input.key, input.data);
+    let (key, data) = (input.key, &input.data);
 
     if !is_x86_feature_detected!("sse4.1") {
         panic!("sse4.1 is not supported");
     }
 
     unsafe {
-        let hash1 = SseHash::force_new(&key).hash64(data);
-        let hash2 = SseHash::force_new(&key).hash64(data);
+        let hash1 = SseHash::force_new(key).hash64(data);
+        let hash2 = SseHash::force_new(key).hash64(data);
         assert_eq!(hash1, hash2);
-        SseHash::force_new(&key).hash128(data);
-        SseHash::force_new(&key).hash256(data);
+        SseHash::force_new(key).hash128(data);
+        SseHash::force_new(key).hash256(data);
     }
 });

--- a/src/avx.rs
+++ b/src/avx.rs
@@ -63,9 +63,9 @@ impl AvxHash {
     /// Creates a new `AvxHash` while circumventing the runtime check for avx2. This function is
     /// unsafe! It will cause a segfault if avx2 is not enabled. Only use this function if you have
     /// benchmarked that the runtime check is significant and you know avx2 is already enabled.
-    pub unsafe fn force_new(key: &Key) -> Self {
+    pub unsafe fn force_new(key: Key) -> Self {
         let mut h = AvxHash {
-            key: *key,
+            key,
             ..Default::default()
         };
         h.reset();
@@ -73,7 +73,7 @@ impl AvxHash {
     }
 
     /// Creates a new `AvxHash` if the avx2 feature is detected.
-    pub fn new(key: &Key) -> Option<Self> {
+    pub fn new(key: Key) -> Option<Self> {
         if is_x86_feature_detected!("avx2") {
             Some(unsafe { Self::force_new(key) })
         } else {

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -102,7 +102,7 @@ impl HighwayHash for HighwayBuilder {
 
 impl HighwayBuilder {
     /// Creates a new hasher based on compilation and runtime capabilities
-    pub fn new(key: &Key) -> Self {
+    pub fn new(key: Key) -> Self {
         #[cfg(target_arch = "x86_64")]
         {
             if let Some(h) = AvxHash::new(key) {
@@ -120,6 +120,6 @@ impl HighwayBuilder {
 
 impl Default for HighwayBuilder {
     fn default() -> Self {
-        HighwayBuilder::new(&Key::default())
+        HighwayBuilder::new(Key::default())
     }
 }

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -9,7 +9,7 @@ pub struct HighwayHasher {
 }
 
 impl HighwayHasher {
-    pub fn new(key: &Key) -> Self {
+    pub fn new(key: Key) -> Self {
         HighwayHasher {
             builder: HighwayBuilder::new(key),
         }
@@ -48,6 +48,6 @@ impl BuildHasher for HighwayBuildHasher {
     type Hasher = HighwayHasher;
 
     fn build_hasher(&self) -> Self::Hasher {
-        HighwayHasher::new(&self.key)
+        HighwayHasher::new(self.key)
     }
 }

--- a/src/key.rs
+++ b/src/key.rs
@@ -2,7 +2,6 @@ use std::ops::Index;
 
 /// Key used in HighwayHash that will drastically change the hash outputs.
 #[derive(Debug, Default, Clone, Copy)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[repr(align(32))]
 pub struct Key(pub [u64; 4]);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@
 //!
 //! // A HighwayBuilder is the recommended approach to hashing,
 //! // as it will select the fastest algorithm available
-//! let mut hasher = HighwayBuilder::new(&key);
+//! let mut hasher = HighwayBuilder::new(key);
 //!
 //! // Append some data
 //! hasher.append(&[255]);
@@ -41,14 +41,14 @@
 //!
 //! // Generate 128bit hash
 //! let key = Key([1, 2, 3, 4]);
-//! let mut hasher128 = HighwayBuilder::new(&key);
+//! let mut hasher128 = HighwayBuilder::new(key);
 //! hasher128.append(&[255]);
 //! let res128: [u64; 2] = hasher128.finalize128();
 //! assert_eq!([0xbb007d2462e77f3c, 0x224508f916b3991f], res128);
 //!
 //! // Generate 256bit hash
 //! let key = Key([1, 2, 3, 4]);
-//! let mut hasher256 = HighwayBuilder::new(&key);
+//! let mut hasher256 = HighwayBuilder::new(key);
 //! hasher256.append(&[255]);
 //! let res256: [u64; 4] = hasher256.finalize256();
 //! let expected: [u64; 4] = [

--- a/src/portable.rs
+++ b/src/portable.rs
@@ -48,9 +48,9 @@ impl HighwayHash for PortableHash {
 
 impl PortableHash {
     /// Create a new `PortableHash` from a `Key`
-    pub fn new(key: &Key) -> Self {
+    pub fn new(key: Key) -> Self {
         let mut h = PortableHash {
-            key: key.clone(),
+            key,
             ..Default::default()
         };
         h.reset();

--- a/src/sse.rs
+++ b/src/sse.rs
@@ -66,9 +66,9 @@ impl SseHash {
     /// Creates a new `SseHash` while circumventing the runtime check for sse4.1. This function is
     /// unsafe! It will cause a segfault if sse4.1 is not enabled. Only use this function if you have
     /// benchmarked that the runtime check is significant and you know sse4.1 is already enabled.
-    pub unsafe fn force_new(key: &Key) -> Self {
+    pub unsafe fn force_new(key: Key) -> Self {
         let mut h = SseHash {
-            key: *key,
+            key,
             ..Default::default()
         };
         h.reset();
@@ -76,7 +76,7 @@ impl SseHash {
     }
 
     /// Create a new `SseHash` if the sse4.1 feature is detected
-    pub fn new(key: &Key) -> Option<Self> {
+    pub fn new(key: Key) -> Option<Self> {
         if is_x86_feature_detected!("sse4.1") {
             Some(unsafe { Self::force_new(key) })
         } else {

--- a/tests/highway-test.rs
+++ b/tests/highway-test.rs
@@ -4,14 +4,14 @@ use highway::{HighwayHash, Key, PortableHash};
 fn portable_hash_simple() {
     let key = Key([1, 2, 3, 4]);
     let b: Vec<u8> = (0..33).map(|x| 128 + x as u8).collect();
-    let hash = PortableHash::new(&key).hash64(&b[..]);
+    let hash = PortableHash::new(key).hash64(&b[..]);
     assert_eq!(0x53c5_16cc_e478_cad7, hash);
 }
 #[test]
 fn portable_hash_append() {
     let key = Key([1, 2, 3, 4]);
     let b: Vec<u8> = (0..33).map(|x| 128 + x as u8).collect();
-    let mut hasher = PortableHash::new(&key);
+    let mut hasher = PortableHash::new(key);
     hasher.append(&b[..]);
     let hash = hasher.finalize64();
     assert_eq!(0x53c5_16cc_e478_cad7, hash);
@@ -20,14 +20,14 @@ fn portable_hash_append() {
 #[test]
 fn portable_hash_simple2() {
     let key = Key([1, 2, 3, 4]);
-    let hash = PortableHash::new(&key).hash64(&[(-1 as i8) as u8]);
+    let hash = PortableHash::new(key).hash64(&[(-1 as i8) as u8]);
     assert_eq!(0x7858_f24d_2d79_b2b2, hash);
 }
 
 #[test]
 fn portable_hash_append2() {
     let key = Key([1, 2, 3, 4]);
-    let mut hasher = PortableHash::new(&key);
+    let mut hasher = PortableHash::new(key);
     hasher.append(&[(-1 as i8) as u8]);
     let hash = hasher.finalize64();
     assert_eq!(0x7858_f24d_2d79_b2b2, hash);
@@ -443,24 +443,24 @@ fn portable_hash_all() {
 
     for i in 0..64 {
         println!("{}", i);
-        let res_128 = u64_to_u128(&PortableHash::new(&key).hash128(&data[..i])[..]);
-        let res_256 = u64_to_u256(&PortableHash::new(&key).hash256(&data[..i])[..]);
-        assert_eq!(expected64[i], PortableHash::new(&key).hash64(&data[..i]));
+        let res_128 = u64_to_u128(&PortableHash::new(key).hash128(&data[..i])[..]);
+        let res_256 = u64_to_u256(&PortableHash::new(key).hash256(&data[..i])[..]);
+        assert_eq!(expected64[i], PortableHash::new(key).hash64(&data[..i]));
         assert_eq!(expected128[i], res_128);
         assert_eq!(expected256[i], res_256);
 
         assert_eq!(expected64[i], {
-            let mut hasher = PortableHash::new(&key);
+            let mut hasher = PortableHash::new(key);
             hasher.append(&data[..i]);
             hasher.finalize64()
         });
         assert_eq!(expected128[i], {
-            let mut hasher = PortableHash::new(&key);
+            let mut hasher = PortableHash::new(key);
             hasher.append(&data[..i]);
             u64_to_u128(&hasher.finalize128()[..])
         });
         assert_eq!(expected256[i], {
-            let mut hasher = PortableHash::new(&key);
+            let mut hasher = PortableHash::new(key);
             hasher.append(&data[..i]);
             u64_to_u256(&hasher.finalize256()[..])
         });
@@ -495,18 +495,18 @@ fn sse_hash_eq_portable() {
     for i in 0..100 {
         println!("{}", i);
         assert_eq!(
-            PortableHash::new(&key).hash64(&data[..i]),
-            SseHash::new(&key).expect("sse4.1").hash64(&data[..i])
+            PortableHash::new(key).hash64(&data[..i]),
+            SseHash::new(key).expect("sse4.1").hash64(&data[..i])
         );
 
         assert_eq!(
-            PortableHash::new(&key).hash128(&data[..i]),
-            SseHash::new(&key).expect("sse4.1").hash128(&data[..i])
+            PortableHash::new(key).hash128(&data[..i]),
+            SseHash::new(key).expect("sse4.1").hash128(&data[..i])
         );
 
         assert_eq!(
-            PortableHash::new(&key).hash256(&data[..i]),
-            SseHash::new(&key).expect("sse4.1").hash256(&data[..i])
+            PortableHash::new(key).hash256(&data[..i]),
+            SseHash::new(key).expect("sse4.1").hash256(&data[..i])
         );
     }
 }
@@ -530,18 +530,18 @@ fn avx_hash_eq_portable() {
     for i in 0..100 {
         println!("{}", i);
         assert_eq!(
-            PortableHash::new(&key).hash64(&data[..i]),
-            AvxHash::new(&key).expect("avx2").hash64(&data[..i])
+            PortableHash::new(key).hash64(&data[..i]),
+            AvxHash::new(key).expect("avx2").hash64(&data[..i])
         );
 
         assert_eq!(
-            PortableHash::new(&key).hash128(&data[..i]),
-            AvxHash::new(&key).expect("avx2").hash128(&data[..i])
+            PortableHash::new(key).hash128(&data[..i]),
+            AvxHash::new(key).expect("avx2").hash128(&data[..i])
         );
 
         assert_eq!(
-            PortableHash::new(&key).hash256(&data[..i]),
-            AvxHash::new(&key).expect("avx2").hash256(&data[..i])
+            PortableHash::new(key).hash256(&data[..i]),
+            AvxHash::new(key).expect("avx2").hash256(&data[..i])
         );
     }
 }
@@ -549,7 +549,7 @@ fn avx_hash_eq_portable() {
 #[test]
 fn portable_survive_crash() {
     let data = include_bytes!("../assets/portable-crash-1");
-    let hash = PortableHash::new(&Key([1, 2, 3, 4])).hash64(&data[..]);
+    let hash = PortableHash::new(Key([1, 2, 3, 4])).hash64(&data[..]);
     assert!(hash != 0);
 }
 
@@ -562,7 +562,7 @@ fn avx_survive_crash() {
     }
 
     let data = include_bytes!("../assets/avx-crash-1");
-    let hash = AvxHash::new(&Key([1, 2, 3, 4]))
+    let hash = AvxHash::new(Key([1, 2, 3, 4]))
         .expect("avx2")
         .hash64(&data[..]);
     assert!(hash != 0);
@@ -583,18 +583,18 @@ fn builder_hash_eq_portable() {
     for i in 0..100 {
         println!("{}", i);
         assert_eq!(
-            PortableHash::new(&key).hash64(&data[..i]),
-            HighwayBuilder::new(&key).hash64(&data[..i])
+            PortableHash::new(key).hash64(&data[..i]),
+            HighwayBuilder::new(key).hash64(&data[..i])
         );
 
         assert_eq!(
-            PortableHash::new(&key).hash128(&data[..i]),
-            HighwayBuilder::new(&key).hash128(&data[..i])
+            PortableHash::new(key).hash128(&data[..i]),
+            HighwayBuilder::new(key).hash128(&data[..i])
         );
 
         assert_eq!(
-            PortableHash::new(&key).hash256(&data[..i]),
-            HighwayBuilder::new(&key).hash256(&data[..i])
+            PortableHash::new(key).hash256(&data[..i]),
+            HighwayBuilder::new(key).hash256(&data[..i])
         );
     }
 }

--- a/tests/properties.rs
+++ b/tests/properties.rs
@@ -7,66 +7,66 @@ mod quick_tests {
     #[quickcheck]
     fn portable64_eq(k1: u64, k2: u64, k3: u64, k4: u64, data: Vec<u8>) -> bool {
         let key = Key([k1, k2, k3, k4]);
-        let hash1 = PortableHash::new(&key).hash64(data.as_slice());
-        let hash2 = PortableHash::new(&key).hash64(data.as_slice());
+        let hash1 = PortableHash::new(key).hash64(data.as_slice());
+        let hash2 = PortableHash::new(key).hash64(data.as_slice());
         hash1 == hash2
     }
 
     #[quickcheck]
     fn portable128_eq(k1: u64, k2: u64, k3: u64, k4: u64, data: Vec<u8>) -> bool {
         let key = Key([k1, k2, k3, k4]);
-        let hash1 = PortableHash::new(&key).hash128(data.as_slice());
-        let hash2 = PortableHash::new(&key).hash128(data.as_slice());
+        let hash1 = PortableHash::new(key).hash128(data.as_slice());
+        let hash2 = PortableHash::new(key).hash128(data.as_slice());
         hash1 == hash2
     }
 
     #[quickcheck]
     fn portable256_eq(k1: u64, k2: u64, k3: u64, k4: u64, data: Vec<u8>) -> bool {
         let key = Key([k1, k2, k3, k4]);
-        let hash1 = PortableHash::new(&key).hash256(data.as_slice());
-        let hash2 = PortableHash::new(&key).hash256(data.as_slice());
+        let hash1 = PortableHash::new(key).hash256(data.as_slice());
+        let hash2 = PortableHash::new(key).hash256(data.as_slice());
         hash1 == hash2
     }
 
     #[quickcheck]
     fn builder64_eq(k1: u64, k2: u64, k3: u64, k4: u64, data: Vec<u8>) -> bool {
         let key = Key([k1, k2, k3, k4]);
-        let hash1 = HighwayBuilder::new(&key).hash64(data.as_slice());
-        let hash2 = HighwayBuilder::new(&key).hash64(data.as_slice());
+        let hash1 = HighwayBuilder::new(key).hash64(data.as_slice());
+        let hash2 = HighwayBuilder::new(key).hash64(data.as_slice());
         hash1 == hash2
     }
 
     #[quickcheck]
     fn builder128_eq(k1: u64, k2: u64, k3: u64, k4: u64, data: Vec<u8>) -> bool {
         let key = Key([k1, k2, k3, k4]);
-        let hash1 = HighwayBuilder::new(&key).hash128(data.as_slice());
-        let hash2 = HighwayBuilder::new(&key).hash128(data.as_slice());
+        let hash1 = HighwayBuilder::new(key).hash128(data.as_slice());
+        let hash2 = HighwayBuilder::new(key).hash128(data.as_slice());
         hash1 == hash2
     }
 
     #[quickcheck]
     fn builder256_eq(k1: u64, k2: u64, k3: u64, k4: u64, data: Vec<u8>) -> bool {
         let key = Key([k1, k2, k3, k4]);
-        let hash1 = HighwayBuilder::new(&key).hash256(data.as_slice());
-        let hash2 = HighwayBuilder::new(&key).hash256(data.as_slice());
+        let hash1 = HighwayBuilder::new(key).hash256(data.as_slice());
+        let hash2 = HighwayBuilder::new(key).hash256(data.as_slice());
         hash1 == hash2
     }
 
     #[quickcheck]
     fn all64_eq(k1: u64, k2: u64, k3: u64, k4: u64, data: Vec<u8>) -> bool {
         let key = Key([k1, k2, k3, k4]);
-        let hash1 = PortableHash::new(&key).hash64(data.as_slice());
-        let hash2 = HighwayBuilder::new(&key).hash64(data.as_slice());
+        let hash1 = PortableHash::new(key).hash64(data.as_slice());
+        let hash2 = HighwayBuilder::new(key).hash64(data.as_slice());
         let mut res = hash1 == hash2;
 
         #[cfg(target_arch = "x86_64")]
         {
             use highway::{AvxHash, SseHash};
-            if let Some(h) = AvxHash::new(&key) {
+            if let Some(h) = AvxHash::new(key) {
                 res &= h.hash64(data.as_slice()) == hash1;
             }
 
-            if let Some(h) = SseHash::new(&key) {
+            if let Some(h) = SseHash::new(key) {
                 res &= h.hash64(data.as_slice()) == hash1;
             }
         }
@@ -77,18 +77,18 @@ mod quick_tests {
     #[quickcheck]
     fn all128_eq(k1: u64, k2: u64, k3: u64, k4: u64, data: Vec<u8>) -> bool {
         let key = Key([k1, k2, k3, k4]);
-        let hash1 = PortableHash::new(&key).hash128(data.as_slice());
-        let hash2 = HighwayBuilder::new(&key).hash128(data.as_slice());
+        let hash1 = PortableHash::new(key).hash128(data.as_slice());
+        let hash2 = HighwayBuilder::new(key).hash128(data.as_slice());
         let mut res = hash1 == hash2;
 
         #[cfg(target_arch = "x86_64")]
         {
             use highway::{AvxHash, SseHash};
-            if let Some(h) = AvxHash::new(&key) {
+            if let Some(h) = AvxHash::new(key) {
                 res &= h.hash128(data.as_slice()) == hash1;
             }
 
-            if let Some(h) = SseHash::new(&key) {
+            if let Some(h) = SseHash::new(key) {
                 res &= h.hash128(data.as_slice()) == hash1;
             }
         }
@@ -99,18 +99,18 @@ mod quick_tests {
     #[quickcheck]
     fn all256_eq(k1: u64, k2: u64, k3: u64, k4: u64, data: Vec<u8>) -> bool {
         let key = Key([k1, k2, k3, k4]);
-        let hash1 = PortableHash::new(&key).hash256(data.as_slice());
-        let hash2 = HighwayBuilder::new(&key).hash256(data.as_slice());
+        let hash1 = PortableHash::new(key).hash256(data.as_slice());
+        let hash2 = HighwayBuilder::new(key).hash256(data.as_slice());
         let mut res = hash1 == hash2;
 
         #[cfg(target_arch = "x86_64")]
         {
             use highway::{AvxHash, SseHash};
-            if let Some(h) = AvxHash::new(&key) {
+            if let Some(h) = AvxHash::new(key) {
                 res &= h.hash256(data.as_slice()) == hash1;
             }
 
-            if let Some(h) = SseHash::new(&key) {
+            if let Some(h) = SseHash::new(key) {
                 res &= h.hash256(data.as_slice()) == hash1;
             }
         }
@@ -126,48 +126,48 @@ mod quick_simd_tests {
     #[quickcheck]
     fn avx64_eq(k1: u64, k2: u64, k3: u64, k4: u64, data: Vec<u8>) -> bool {
         let key = Key([k1, k2, k3, k4]);
-        let hash1 = AvxHash::new(&key).map(|x| x.hash64(data.as_slice()));
-        let hash2 = AvxHash::new(&key).map(|x| x.hash64(data.as_slice()));
+        let hash1 = AvxHash::new(key).map(|x| x.hash64(data.as_slice()));
+        let hash2 = AvxHash::new(key).map(|x| x.hash64(data.as_slice()));
         hash1 == hash2
     }
 
     #[quickcheck]
     fn avx128_eq(k1: u64, k2: u64, k3: u64, k4: u64, data: Vec<u8>) -> bool {
         let key = Key([k1, k2, k3, k4]);
-        let hash1 = AvxHash::new(&key).map(|x| x.hash128(data.as_slice()));
-        let hash2 = AvxHash::new(&key).map(|x| x.hash128(data.as_slice()));
+        let hash1 = AvxHash::new(key).map(|x| x.hash128(data.as_slice()));
+        let hash2 = AvxHash::new(key).map(|x| x.hash128(data.as_slice()));
         hash1 == hash2
     }
 
     #[quickcheck]
     fn avx256_eq(k1: u64, k2: u64, k3: u64, k4: u64, data: Vec<u8>) -> bool {
         let key = Key([k1, k2, k3, k4]);
-        let hash1 = AvxHash::new(&key).map(|x| x.hash256(data.as_slice()));
-        let hash2 = AvxHash::new(&key).map(|x| x.hash256(data.as_slice()));
+        let hash1 = AvxHash::new(key).map(|x| x.hash256(data.as_slice()));
+        let hash2 = AvxHash::new(key).map(|x| x.hash256(data.as_slice()));
         hash1 == hash2
     }
 
     #[quickcheck]
     fn sse64_eq(k1: u64, k2: u64, k3: u64, k4: u64, data: Vec<u8>) -> bool {
         let key = Key([k1, k2, k3, k4]);
-        let hash1 = SseHash::new(&key).map(|x| x.hash64(data.as_slice()));
-        let hash2 = SseHash::new(&key).map(|x| x.hash64(data.as_slice()));
+        let hash1 = SseHash::new(key).map(|x| x.hash64(data.as_slice()));
+        let hash2 = SseHash::new(key).map(|x| x.hash64(data.as_slice()));
         hash1 == hash2
     }
 
     #[quickcheck]
     fn sse128_eq(k1: u64, k2: u64, k3: u64, k4: u64, data: Vec<u8>) -> bool {
         let key = Key([k1, k2, k3, k4]);
-        let hash1 = SseHash::new(&key).map(|x| x.hash128(data.as_slice()));
-        let hash2 = SseHash::new(&key).map(|x| x.hash128(data.as_slice()));
+        let hash1 = SseHash::new(key).map(|x| x.hash128(data.as_slice()));
+        let hash2 = SseHash::new(key).map(|x| x.hash128(data.as_slice()));
         hash1 == hash2
     }
 
     #[quickcheck]
     fn sse256_eq(k1: u64, k2: u64, k3: u64, k4: u64, data: Vec<u8>) -> bool {
         let key = Key([k1, k2, k3, k4]);
-        let hash1 = SseHash::new(&key).map(|x| x.hash256(data.as_slice()));
-        let hash2 = SseHash::new(&key).map(|x| x.hash256(data.as_slice()));
+        let hash1 = SseHash::new(key).map(|x| x.hash256(data.as_slice()));
+        let hash2 = SseHash::new(key).map(|x| x.hash256(data.as_slice()));
         hash1 == hash2
     }
 }


### PR DESCRIPTION
Underneath the constructor for each implementation they would clone /
copy the key for themselves. The need to clone / copy a key should be at
the client level, not in the implementation. Implicitly cloning 32 bytes
for every hash probably isn't egregious but it's better to have good API
design.