### PR TITLE
Use ptr::read_unaligned in portable for performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ function.
  - ✔ zero dependencies
  - ✔ generate 64, 128, and 256bit hashes
  - ✔ > 10 GB/s with SIMD (SSE 4.1 & AVX 2) aware instructions on x86 architectures
- - ✔ > 1 GB/s portable implementation with zero unsafe constructs
+ - ✔ > 1 GB/s portable implementation with only one instance of `unsafe`
  - ✔ passes reference test suite
  - ✔ incremental / streaming hashes
  - ✔ zero heap allocations

--- a/src/avx.rs
+++ b/src/avx.rs
@@ -263,17 +263,13 @@ impl AvxHash {
         match self.buffer.fill(data) {
             Filled::Consumed => {}
             Filled::Full(new_data) => {
-                let packet = AvxHash::to_lanes(self.buffer.as_slice());
-                self.update(packet);
-
-                let mut rest = &new_data[..];
-                while rest.len() >= PACKET_SIZE {
-                    let packet = AvxHash::to_lanes(&rest);
-                    self.update(packet);
-                    rest = &rest[PACKET_SIZE..];
+                self.update(AvxHash::to_lanes(self.buffer.as_slice()));
+                let mut chunks = new_data.chunks_exact(PACKET_SIZE);
+                while let Some(chunk) = chunks.next() {
+                    self.update(AvxHash::to_lanes(chunk));
                 }
 
-                self.buffer.set_to(rest);
+                self.buffer.set_to(chunks.remainder());
             }
         }
     }

--- a/src/portable.rs
+++ b/src/portable.rs
@@ -255,16 +255,13 @@ impl PortableHash {
         match self.buffer.fill(data) {
             Filled::Consumed => {}
             Filled::Full(new_data) => {
-                let l = PortableHash::to_lanes(self.buffer.as_slice());
-                self.update(l);
-
-                let mut rest = &new_data[..];
-                while rest.len() >= PACKET_SIZE {
-                    self.update_packet(&rest);
-                    rest = &rest[PACKET_SIZE..];
+                self.update(PortableHash::to_lanes(self.buffer.as_slice()));
+                let mut chunks = new_data.chunks_exact(PACKET_SIZE);
+                while let Some(chunk) = chunks.next() {
+                    self.update(PortableHash::to_lanes(chunk));
                 }
 
-                self.buffer.set_to(rest);
+                self.buffer.set_to(chunks.remainder());
             }
         }
     }

--- a/src/portable.rs
+++ b/src/portable.rs
@@ -193,17 +193,18 @@ impl PortableHash {
         );
     }
 
-    fn update_packet(&mut self, packet: &[u8]) {
-        self.update(PortableHash::to_lanes(packet));
-    }
-
     fn to_lanes(d: &[u8]) -> [u64; 4] {
-        [
-            u64::from_le_bytes([d[0], d[1], d[2], d[3], d[4], d[5], d[6], d[7]]),
-            u64::from_le_bytes([d[8], d[9], d[10], d[11], d[12], d[13], d[14], d[15]]),
-            u64::from_le_bytes([d[16], d[17], d[18], d[19], d[20], d[21], d[22], d[23]]),
-            u64::from_le_bytes([d[24], d[25], d[26], d[27], d[28], d[29], d[30], d[31]]),
-        ]
+        // Use of ptr::read_unaligned gave a 60% throughput increase for large payloads. I'm on the
+        // lookout for a safe alternative that is as performant
+        debug_assert!(d.len() >= std::mem::size_of::<[u64; 4]>());
+        unsafe {
+            [
+                (d.as_ptr().offset(0) as *const u64).read_unaligned(),
+                (d.as_ptr().offset(8) as *const u64).read_unaligned(),
+                (d.as_ptr().offset(16) as *const u64).read_unaligned(),
+                (d.as_ptr().offset(24) as *const u64).read_unaligned(),
+            ]
+        }
     }
 
     fn rotate_32_by(count: u64, lanes: &mut [u64; 4]) {
@@ -248,7 +249,7 @@ impl PortableHash {
         let size = self.buffer.len() as u64;
         self.update_lanes(size);
         let packet = PortableHash::remainder(self.buffer.as_slice());
-        self.update_packet(&packet);
+        self.update(PortableHash::to_lanes(&packet));
     }
 
     fn append(&mut self, data: &[u8]) {

--- a/src/sse.rs
+++ b/src/sse.rs
@@ -291,14 +291,13 @@ impl SseHash {
                 let (packetH, packetL) = SseHash::to_lanes(self.buffer.as_slice());
                 self.update(packetH, packetL);
 
-                let mut rest = &new_data[..];
-                while rest.len() >= PACKET_SIZE {
-                    let (packetH, packetL) = SseHash::to_lanes(&rest);
+                let mut chunks = new_data.chunks_exact(PACKET_SIZE);
+                while let Some(chunk) = chunks.next() {
+                    let (packetH, packetL) = SseHash::to_lanes(chunk);
                     self.update(packetH, packetL);
-                    rest = &rest[PACKET_SIZE..];
                 }
 
-                self.buffer.set_to(rest);
+                self.buffer.set_to(chunks.remainder());
             }
         }
     }


### PR DESCRIPTION
Benchmarks on large inputs show a 60% increase in throughput for
the portable highway hash implementation

This PR also uses `chunks_exact` for a bit more readability in avx and sse implementations