### PR TITLE
Implements both the Hasher and Write trait for any HighwayHash

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,6 +18,7 @@ jobs:
       TARGET:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         build:
         - pinned

--- a/README.md
+++ b/README.md
@@ -114,6 +114,18 @@ map.insert(1, 2);
 assert_eq!(map.get(&1), Some(&2));
 ```
 
+Hashing a file, or anything implementing `Read`
+
+```rust
+use std::fs::File;
+use highway::{HighwayHasher, HighwayHash};
+let mut file = File::open(...)?;
+let mut hasher = HighwayHasher::default();
+std::io::copy(&mut file, &mut hasher)?;
+let hash64 = hasher.finish(); // core Hasher API
+let hash256 = hasher.finalize256(); // highway API
+```
+
 ## Use Cases
 
 HighwayHash can be used against untrusted user input where weak hashes can't be used due to exploitation, verified cryptographic hashes are too slow, and a strong hash function meets requirements. Some specific scenarios given by the authors of HighwayHash:

--- a/README.md
+++ b/README.md
@@ -118,12 +118,14 @@ Hashing a file, or anything implementing `Read`
 
 ```rust
 use std::fs::File;
-use highway::{HighwayHasher, HighwayHash};
-let mut file = File::open(...)?;
-let mut hasher = HighwayHasher::default();
-std::io::copy(&mut file, &mut hasher)?;
+use std::hash::Hasher;
+use highway::{PortableHash, HighwayHash};
+
+let mut file = File::open("./README.md").unwrap();
+let mut hasher = PortableHash::default();
+std::io::copy(&mut file, &mut hasher).unwrap();
 let hash64 = hasher.finish(); // core Hasher API
-let hash256 = hasher.finalize256(); // highway API
+let hash256 = hasher.finalize256(); // HighwayHash API
 ```
 
 ## Use Cases

--- a/src/avx.rs
+++ b/src/avx.rs
@@ -46,16 +46,16 @@ impl HighwayHash for AvxHash {
         }
     }
 
-    fn finalize64(mut self) -> u64 {
-        unsafe { Self::finalize64(&mut self) }
+    fn finalize64(&self) -> u64 {
+        unsafe { Self::finalize64(&mut self.clone()) }
     }
 
-    fn finalize128(mut self) -> [u64; 2] {
-        unsafe { Self::finalize128(&mut self) }
+    fn finalize128(&self) -> [u64; 2] {
+        unsafe { Self::finalize128(&mut self.clone()) }
     }
 
-    fn finalize256(mut self) -> [u64; 4] {
-        unsafe { Self::finalize256(&mut self) }
+    fn finalize256(&self) -> [u64; 4] {
+        unsafe { Self::finalize256(&mut self.clone()) }
     }
 }
 

--- a/src/avx.rs
+++ b/src/avx.rs
@@ -46,16 +46,16 @@ impl HighwayHash for AvxHash {
         }
     }
 
-    fn finalize64(&self) -> u64 {
-        unsafe { Self::finalize64(&mut self.clone()) }
+    fn finalize64(mut self) -> u64 {
+        unsafe { Self::finalize64(&mut self) }
     }
 
-    fn finalize128(&self) -> [u64; 2] {
-        unsafe { Self::finalize128(&mut self.clone()) }
+    fn finalize128(mut self) -> [u64; 2] {
+        unsafe { Self::finalize128(&mut self) }
     }
 
-    fn finalize256(&self) -> [u64; 4] {
-        unsafe { Self::finalize256(&mut self.clone()) }
+    fn finalize256(mut self) -> [u64; 4] {
+        unsafe { Self::finalize256(&mut self) }
     }
 }
 
@@ -274,3 +274,6 @@ impl AvxHash {
         }
     }
 }
+
+impl_write!(AvxHash);
+impl_hasher!(AvxHash);

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -69,8 +69,8 @@ impl HighwayHash for HighwayBuilder {
         }
     }
 
-    fn finalize64(&self) -> u64 {
-        match &self.0 {
+    fn finalize64(self) -> u64 {
+        match self.0 {
             HighwayChoices::Portable(x) => x.finalize64(),
             #[cfg(target_arch = "x86_64")]
             HighwayChoices::Avx(x) => x.finalize64(),
@@ -79,8 +79,8 @@ impl HighwayHash for HighwayBuilder {
         }
     }
 
-    fn finalize128(&self) -> [u64; 2] {
-        match &self.0 {
+    fn finalize128(self) -> [u64; 2] {
+        match self.0 {
             HighwayChoices::Portable(x) => x.finalize128(),
             #[cfg(target_arch = "x86_64")]
             HighwayChoices::Avx(x) => x.finalize128(),
@@ -89,8 +89,8 @@ impl HighwayHash for HighwayBuilder {
         }
     }
 
-    fn finalize256(&self) -> [u64; 4] {
-        match &self.0 {
+    fn finalize256(self) -> [u64; 4] {
+        match self.0 {
             HighwayChoices::Portable(x) => x.finalize256(),
             #[cfg(target_arch = "x86_64")]
             HighwayChoices::Avx(x) => x.finalize256(),
@@ -123,3 +123,6 @@ impl Default for HighwayBuilder {
         HighwayBuilder::new(Key::default())
     }
 }
+
+impl_write!(HighwayBuilder);
+impl_hasher!(HighwayBuilder);

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -69,8 +69,8 @@ impl HighwayHash for HighwayBuilder {
         }
     }
 
-    fn finalize64(self) -> u64 {
-        match self.0 {
+    fn finalize64(&self) -> u64 {
+        match &self.0 {
             HighwayChoices::Portable(x) => x.finalize64(),
             #[cfg(target_arch = "x86_64")]
             HighwayChoices::Avx(x) => x.finalize64(),
@@ -79,8 +79,8 @@ impl HighwayHash for HighwayBuilder {
         }
     }
 
-    fn finalize128(self) -> [u64; 2] {
-        match self.0 {
+    fn finalize128(&self) -> [u64; 2] {
+        match &self.0 {
             HighwayChoices::Portable(x) => x.finalize128(),
             #[cfg(target_arch = "x86_64")]
             HighwayChoices::Avx(x) => x.finalize128(),
@@ -89,8 +89,8 @@ impl HighwayHash for HighwayBuilder {
         }
     }
 
-    fn finalize256(self) -> [u64; 4] {
-        match self.0 {
+    fn finalize256(&self) -> [u64; 4] {
+        match &self.0 {
             HighwayChoices::Portable(x) => x.finalize256(),
             #[cfg(target_arch = "x86_64")]
             HighwayChoices::Avx(x) => x.finalize256(),

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -33,6 +33,16 @@ impl Hasher for HighwayHasher {
     }
 }
 
+impl std::io::Write for HighwayHasher {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.builder.append(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
 #[derive(Debug, Default)]
 pub struct HighwayBuildHasher {
     key: Key,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,6 +98,21 @@ let mut map =
 map.insert(1, 2);
 assert_eq!(map.get(&1), Some(&2));
 ```
+
+Hashing a file, or anything implementing `Read`
+
+```rust
+use std::fs::File;
+use std::hash::Hasher;
+use highway::{PortableHash, HighwayHash};
+
+let mut file = File::open("./README.md").unwrap();
+let mut hasher = PortableHash::default();
+std::io::copy(&mut file, &mut hasher).unwrap();
+let hash64 = hasher.finish(); // core Hasher API
+let hash256 = hasher.finalize256(); // HighwayHash API
+```
+
 */
 #![allow(non_snake_case)]
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -29,7 +29,7 @@ macro_rules! impl_hasher {
             fn write(&mut self, bytes: &[u8]) {
                 crate::HighwayHash::append(self, bytes);
             }
-            fn finish(&self) -> ::std::primitive::u64 {
+            fn finish(&self) -> u64 {
                 crate::HighwayHash::finalize64(self.clone())
             }
         }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -8,3 +8,30 @@ macro_rules! _mm_shuffle {
         ($z << 6) | ($y << 4) | ($x << 2) | $w
     };
 }
+
+macro_rules! impl_write {
+    ($hasher_struct:ident) => {
+        impl ::std::io::Write for $hasher_struct {
+            fn write(&mut self, bytes: &[u8]) -> ::std::io::Result<usize> {
+                crate::HighwayHash::append(self, bytes);
+                Ok(bytes.len())
+            }
+            fn flush(&mut self) -> ::std::io::Result<()> {
+                Ok(())
+            }
+        }
+    };
+}
+
+macro_rules! impl_hasher {
+    ($hasher_struct:ident) => {
+        impl ::core::hash::Hasher for $hasher_struct {
+            fn write(&mut self, bytes: &[u8]) {
+                crate::HighwayHash::append(self, bytes);
+            }
+            fn finish(&self) -> ::std::primitive::u64 {
+                crate::HighwayHash::finalize64(self.clone())
+            }
+        }
+    };
+}

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -10,10 +10,10 @@ macro_rules! _mm_shuffle {
 }
 
 macro_rules! impl_write {
-    ($hasher_struct:ident) => {
+    ($hasher_struct:ty) => {
         impl ::std::io::Write for $hasher_struct {
             fn write(&mut self, bytes: &[u8]) -> ::std::io::Result<usize> {
-                crate::HighwayHash::append(self, bytes);
+                $crate::HighwayHash::append(self, bytes);
                 Ok(bytes.len())
             }
             fn flush(&mut self) -> ::std::io::Result<()> {
@@ -24,13 +24,13 @@ macro_rules! impl_write {
 }
 
 macro_rules! impl_hasher {
-    ($hasher_struct:ident) => {
+    ($hasher_struct:ty) => {
         impl ::core::hash::Hasher for $hasher_struct {
             fn write(&mut self, bytes: &[u8]) {
-                crate::HighwayHash::append(self, bytes);
+                $crate::HighwayHash::append(self, bytes);
             }
             fn finish(&self) -> u64 {
-                crate::HighwayHash::finalize64(self.clone())
+                $crate::HighwayHash::finalize64(self.clone())
             }
         }
     };

--- a/src/portable.rs
+++ b/src/portable.rs
@@ -33,16 +33,16 @@ impl HighwayHash for PortableHash {
         self.append(data);
     }
 
-    fn finalize64(mut self) -> u64 {
-        Self::finalize64(&mut self)
+    fn finalize64(&self) -> u64 {
+        Self::finalize64(&mut self.clone())
     }
 
-    fn finalize128(mut self) -> [u64; 2] {
-        Self::finalize128(&mut self)
+    fn finalize128(&self) -> [u64; 2] {
+        Self::finalize128(&mut self.clone())
     }
 
-    fn finalize256(mut self) -> [u64; 4] {
-        Self::finalize256(&mut self)
+    fn finalize256(&self) -> [u64; 4] {
+        Self::finalize256(&mut self.clone())
     }
 }
 

--- a/src/portable.rs
+++ b/src/portable.rs
@@ -33,16 +33,16 @@ impl HighwayHash for PortableHash {
         self.append(data);
     }
 
-    fn finalize64(&self) -> u64 {
-        Self::finalize64(&mut self.clone())
+    fn finalize64(mut self) -> u64 {
+        Self::finalize64(&mut self)
     }
 
-    fn finalize128(&self) -> [u64; 2] {
-        Self::finalize128(&mut self.clone())
+    fn finalize128(mut self) -> [u64; 2] {
+        Self::finalize128(&mut self)
     }
 
-    fn finalize256(&self) -> [u64; 4] {
-        Self::finalize256(&mut self.clone())
+    fn finalize256(mut self) -> [u64; 4] {
+        Self::finalize256(&mut self)
     }
 }
 
@@ -267,3 +267,6 @@ impl PortableHash {
         }
     }
 }
+
+impl_write!(PortableHash);
+impl_hasher!(PortableHash);

--- a/src/sse.rs
+++ b/src/sse.rs
@@ -49,16 +49,16 @@ impl HighwayHash for SseHash {
         }
     }
 
-    fn finalize64(&self) -> u64 {
-        unsafe { Self::finalize64(&mut self.clone()) }
+    fn finalize64(mut self) -> u64 {
+        unsafe { Self::finalize64(&mut self) }
     }
 
-    fn finalize128(&self) -> [u64; 2] {
-        unsafe { Self::finalize128(&mut self.clone()) }
+    fn finalize128(mut self) -> [u64; 2] {
+        unsafe { Self::finalize128(&mut self) }
     }
 
-    fn finalize256(&self) -> [u64; 4] {
-        unsafe { Self::finalize256(&mut self.clone()) }
+    fn finalize256(mut self) -> [u64; 4] {
+        unsafe { Self::finalize256(&mut self) }
     }
 }
 
@@ -302,3 +302,6 @@ impl SseHash {
         }
     }
 }
+
+impl_write!(SseHash);
+impl_hasher!(SseHash);

--- a/src/sse.rs
+++ b/src/sse.rs
@@ -49,16 +49,16 @@ impl HighwayHash for SseHash {
         }
     }
 
-    fn finalize64(mut self) -> u64 {
-        unsafe { Self::finalize64(&mut self) }
+    fn finalize64(&self) -> u64 {
+        unsafe { Self::finalize64(&mut self.clone()) }
     }
 
-    fn finalize128(mut self) -> [u64; 2] {
-        unsafe { Self::finalize128(&mut self) }
+    fn finalize128(&self) -> [u64; 2] {
+        unsafe { Self::finalize128(&mut self.clone()) }
     }
 
-    fn finalize256(mut self) -> [u64; 4] {
-        unsafe { Self::finalize256(&mut self) }
+    fn finalize256(&self) -> [u64; 4] {
+        unsafe { Self::finalize256(&mut self.clone()) }
     }
 }
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -20,30 +20,11 @@ pub trait HighwayHash {
     fn append(&mut self, data: &[u8]);
 
     /// Consumes the hasher to return the 64bit hash
-    fn finalize64(&self) -> u64;
+    fn finalize64(self) -> u64;
 
     /// Consumes the hasher to return the 128bit hash
-    fn finalize128(&self) -> [u64; 2];
+    fn finalize128(self) -> [u64; 2];
 
     /// Consumes the hasher to return the 256bit hash
-    fn finalize256(&self) -> [u64; 4];
-}
-
-impl core::hash::Hasher for dyn HighwayHash {
-    fn write(&mut self, bytes: &[u8]) {
-        self.append(bytes);
-    }
-    fn finish(&self) -> u64 {
-        self.clone().finalize64()
-    }
-}
-
-impl std::io::Write for dyn HighwayHash {
-    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-        self.append(buf);
-        Ok(buf.len())
-    }
-    fn flush(&mut self) -> std::io::Result<()> {
-        Ok(())
-    }
+    fn finalize256(self) -> [u64; 4];
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -20,11 +20,30 @@ pub trait HighwayHash {
     fn append(&mut self, data: &[u8]);
 
     /// Consumes the hasher to return the 64bit hash
-    fn finalize64(self) -> u64;
+    fn finalize64(&self) -> u64;
 
     /// Consumes the hasher to return the 128bit hash
-    fn finalize128(self) -> [u64; 2];
+    fn finalize128(&self) -> [u64; 2];
 
     /// Consumes the hasher to return the 256bit hash
-    fn finalize256(self) -> [u64; 4];
+    fn finalize256(&self) -> [u64; 4];
+}
+
+impl core::hash::Hasher for dyn HighwayHash {
+    fn write(&mut self, bytes: &[u8]) {
+        self.append(bytes);
+    }
+    fn finish(&self) -> u64 {
+        self.clone().finalize64()
+    }
+}
+
+impl std::io::Write for dyn HighwayHash {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.append(buf);
+        Ok(buf.len())
+    }
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
 }

--- a/tests/traits.rs
+++ b/tests/traits.rs
@@ -1,0 +1,19 @@
+fn hash<H>() -> std::io::Result<u64>
+where
+    H: std::hash::Hasher,
+    H: std::io::Write,
+    H: Default,
+{
+    let mut reader = "foobar".as_bytes();
+    let mut hasher = H::default();
+    std::io::copy(&mut reader, &mut hasher)?;
+    Ok(std::hash::Hasher::finish(&hasher))
+}
+
+#[test]
+fn hashers_should_implement_write_and_hasher() {
+    assert!(hash::<highway::AvxHash>().is_ok());
+    assert!(hash::<highway::PortableHash>().is_ok());
+    assert!(hash::<highway::SseHash>().is_ok());
+    assert!(hash::<highway::HighwayHasher>().is_ok());
+}

--- a/tests/traits.rs
+++ b/tests/traits.rs
@@ -11,10 +11,13 @@ where
 }
 
 #[test]
-#[cfg(target_arch = "x86_64")]
 fn hashers_should_implement_write_and_hasher() {
-    assert!(hash::<highway::AvxHash>().is_ok());
+    if is_x86_feature_detected!("avx2") {
+        assert!(hash::<highway::AvxHash>().is_ok());
+    }
+    if is_x86_feature_detected!("sse4.1") {
+        assert!(hash::<highway::SseHash>().is_ok());
+    }
     assert!(hash::<highway::PortableHash>().is_ok());
-    assert!(hash::<highway::SseHash>().is_ok());
     assert!(hash::<highway::HighwayHasher>().is_ok());
 }

--- a/tests/traits.rs
+++ b/tests/traits.rs
@@ -11,6 +11,7 @@ where
 }
 
 #[test]
+#[cfg(target_arch = "x86_64")]
 fn hashers_should_implement_write_and_hasher() {
     assert!(hash::<highway::AvxHash>().is_ok());
     assert!(hash::<highway::PortableHash>().is_ok());


### PR DESCRIPTION
I'm opening this PR not really to merge that as it is (I don't think this is _good_), but to open the discussion about how to best implement `core::hash::Hasher` on the different highway hasher structs.

This is a design proof of concept, but it changes a lot of things, both in `HighwayHash` trait API, and at runtime the `Clone`-ing of hasher structs. And I'm not too happy about these changes.

Edit:

Using macros instead of trait objects allows the same thing but without changing any of the API. I think this is better. Though, if you want those features is still up to you of course.
