### PR TITLE
Alias HighwayHasher to HighwayBuilder

### DIFF
--- a/src/hash.rs
+++ b/src/hash.rs
@@ -1,48 +1,9 @@
 use crate::builder::HighwayBuilder;
 use crate::key::Key;
-use crate::traits::HighwayHash;
-use std::hash::{BuildHasher, Hasher};
+use std::hash::BuildHasher;
 
-#[derive(Debug, Default)]
-pub struct HighwayHasher {
-    builder: HighwayBuilder,
-}
+pub type HighwayHasher = HighwayBuilder;
 
-impl HighwayHasher {
-    pub fn new(key: Key) -> Self {
-        HighwayHasher {
-            builder: HighwayBuilder::new(key),
-        }
-    }
-}
-
-impl Hasher for HighwayHasher {
-    fn write(&mut self, bytes: &[u8]) {
-        self.builder.append(bytes);
-    }
-
-    fn finish(&self) -> u64 {
-        // Reasons why we need to clone. finalize64` mutates internal state so either we need our
-        // Hasher to consume itself or receive a mutable reference on `finish`. We receive neither,
-        // due to finish being a misnomer (additional writes could be expected) and it's intended
-        // for the hasher to merely return it's current state. The issue with HighwayHash is that
-        // there are several rounds of permutations when finalizing a value, and internal state is
-        // modified during that process. We work around these constraints by cloning the hasher and
-        // finalizing that one.
-        self.builder.clone().finalize64()
-    }
-}
-
-impl std::io::Write for HighwayHasher {
-    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-        self.builder.append(buf);
-        Ok(buf.len())
-    }
-
-    fn flush(&mut self) -> std::io::Result<()> {
-        Ok(())
-    }
-}
 #[derive(Debug, Default)]
 pub struct HighwayBuildHasher {
     key: Key,
@@ -58,6 +19,6 @@ impl BuildHasher for HighwayBuildHasher {
     type Hasher = HighwayHasher;
 
     fn build_hasher(&self) -> Self::Hasher {
-        HighwayHasher::new(self.key)
+        HighwayBuilder::new(self.key)
     }
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -30,6 +30,13 @@ macro_rules! impl_hasher {
                 $crate::HighwayHash::append(self, bytes);
             }
             fn finish(&self) -> u64 {
+                // Reasons why we need to clone. finalize64` mutates internal state so either we need our
+                // Hasher to consume itself or receive a mutable reference on `finish`. We receive neither,
+                // due to finish being a misnomer (additional writes could be expected) and it's intended
+                // for the hasher to merely return it's current state. The issue with HighwayHash is that
+                // there are several rounds of permutations when finalizing a value, and internal state is
+                // modified during that process. We work around these constraints by cloning the hasher and
+                // finalizing that one.
                 $crate::HighwayHash::finalize64(self.clone())
             }
         }


### PR DESCRIPTION
Now that all highway hash implementations implement the `Write` and
`Hash` traits, the `HighwayHasher` has been made redundant. To preserve
backwards compatibility (and since it has a better name than
`HighwayBuilder`), `HighwayHasher` is now an alias to `HighwayBuilder`

cc @jRimbault 