### PR TITLE
Add no_std compatibility

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -87,6 +87,10 @@ jobs:
       if: matrix.build != 'pinned'
       run: ${{ env.CARGO }} test --verbose $TARGET
 
+    - name: No Std Tests
+      if: matrix.build != 'pinned'
+      run: ${{ env.CARGO }} test --no-default-features --verbose $TARGET
+
       # If you are wondering why we run tests in release mode, it's
       # because sometimes tests in debug mode hide undefined behavior:
       # https://stackoverflow.com/q/52433389/433785

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,10 +5,14 @@ authors = ["Nick Babcock <nbabcock19@hotmail.com>"]
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/nickbabcock/highway-rs"
-categories = ["algorithms", "cryptography"]
+categories = ["algorithms", "cryptography", "no-std"]
 description = "Native Rust port of Google's HighwayHash, which makes use of SIMD instructions for a fast and strong hash function"
 keywords = ["HighwayHash", "hash", "simd", "avx"]
 edition = "2018"
+
+[features]
+default = ["std"]
+std = []
 
 [dev-dependencies]
 criterion = "0.3.0"

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ function.
  - ✔ passes reference test suite
  - ✔ incremental / streaming hashes
  - ✔ zero heap allocations
+ - ✔ `no_std` compatible
  - ✔ fuzzed against in-house fuzzing suite
 
 ## Caution
@@ -136,6 +137,10 @@ HighwayHash can be used against untrusted user input where weak hashes can't be 
 - Use 256bit hashes for checksums. Think file storage (S3) or any longer lived data where there is a need for strong guarantees against collisions.
 
 Highwayhash may not be a good fit if the payloads trend small (< 100 bytes) and speed is up of the upmost importance, as Highwayhash hits its stride at larger payloads.
+
+## Crate Features
+
+`highway` is `no_std` compatible when the default features are disabled. Be aware that the `no_std` version is unable to detect CPU features and so will always default to the portable implementation. If building for a known SSE 4.1 or AVX 2 machine (and the majority of machines in the last decade will support SSE 4.1), these hashers can still be constructed with `force_new`. 
 
 ## Benchmarks
 

--- a/src/avx.rs
+++ b/src/avx.rs
@@ -4,11 +4,12 @@ use crate::key::Key;
 use crate::traits::HighwayHash;
 use crate::v2x64u::V2x64U;
 use crate::v4x64u::V4x64U;
-use std::arch::x86_64::*;
+use core::arch::x86_64::*;
 
 /// AVX empowered implementation that will only work on `x86_64` with avx2 enabled at the CPU
 /// level.
-#[derive(Debug, Default, Clone)]
+#[cfg_attr(feature = "std", derive(Debug))]
+#[derive(Default, Clone)]
 pub struct AvxHash {
     key: Key,
     buffer: HashPacket,
@@ -78,9 +79,18 @@ impl AvxHash {
 
     /// Creates a new `AvxHash` if the avx2 feature is detected.
     pub fn new(key: Key) -> Option<Self> {
-        if is_x86_feature_detected!("avx2") {
-            Some(unsafe { Self::force_new(key) })
-        } else {
+        #[cfg(feature = "std")]
+        {
+            if is_x86_feature_detected!("avx2") {
+                Some(unsafe { Self::force_new(key) })
+            } else {
+                None
+            }
+        }
+
+        #[cfg(not(feature = "std"))]
+        {
+            let _key = key;
             None
         }
     }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,14 +1,15 @@
 use crate::key::Key;
 use crate::portable::PortableHash;
 use crate::traits::HighwayHash;
-use std::default::Default;
+use core::default::Default;
 
 #[cfg(target_arch = "x86_64")]
 use crate::avx::AvxHash;
 #[cfg(target_arch = "x86_64")]
 use crate::sse::SseHash;
 
-#[derive(Debug, Clone)]
+#[cfg_attr(feature = "std", derive(Debug))]
+#[derive(Clone)]
 enum HighwayChoices {
     Portable(PortableHash),
     #[cfg(target_arch = "x86_64")]
@@ -25,7 +26,8 @@ enum HighwayChoices {
 ///  - AvxHash
 ///  - SseHash
 ///  - PortableHash
-#[derive(Debug, Clone)]
+#[cfg_attr(feature = "std", derive(Debug))]
+#[derive(Clone)]
 pub struct HighwayBuilder(HighwayChoices);
 
 impl HighwayHash for HighwayBuilder {

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -1,6 +1,6 @@
 use crate::builder::HighwayBuilder;
 use crate::key::Key;
-use std::hash::BuildHasher;
+use core::hash::BuildHasher;
 
 pub type HighwayHasher = HighwayBuilder;
 

--- a/src/key.rs
+++ b/src/key.rs
@@ -1,4 +1,4 @@
-use std::ops::Index;
+use core::ops::Index;
 
 /// Key used in HighwayHash that will drastically change the hash outputs.
 #[derive(Debug, Default, Clone, Copy)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,6 +72,8 @@ assert_eq!(expected, res256);
 Use highway hash in standard rust collections
 
 ```rust
+# #[cfg(feature = "std")]
+# {
 use std::collections::HashMap;
 use highway::{HighwayBuildHasher, Key};
 let mut map =
@@ -84,11 +86,14 @@ let mut map =
 
 map.insert(1, 2);
 assert_eq!(map.get(&1), Some(&2));
+# }
 ```
 
 Or if utilizing a key is not important, one can use the default
 
 ```rust
+# #[cfg(feature = "std")]
+# {
 use std::collections::HashMap;
 use std::hash::BuildHasherDefault;
 use highway::HighwayHasher;
@@ -97,11 +102,14 @@ let mut map =
 
 map.insert(1, 2);
 assert_eq!(map.get(&1), Some(&2));
+# }
 ```
 
 Hashing a file, or anything implementing `Read`
 
 ```rust
+# #[cfg(feature = "std")]
+# {
 use std::fs::File;
 use std::hash::Hasher;
 use highway::{PortableHash, HighwayHash};
@@ -111,10 +119,12 @@ let mut hasher = PortableHash::default();
 std::io::copy(&mut file, &mut hasher).unwrap();
 let hash64 = hasher.finish(); // core Hasher API
 let hash256 = hasher.finalize256(); // HighwayHash API
+# }
 ```
 
 */
 #![allow(non_snake_case)]
+#![cfg_attr(all(not(feature = "std"), not(test)), no_std)]
 
 #[macro_use]
 mod macros;
@@ -145,5 +155,6 @@ pub use crate::avx::AvxHash;
 #[cfg(target_arch = "x86_64")]
 pub use crate::sse::SseHash;
 
+#[cfg(feature = "std")]
 #[cfg(doctest)]
 doc_comment::doctest!("../README.md");

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -11,6 +11,7 @@ macro_rules! _mm_shuffle {
 
 macro_rules! impl_write {
     ($hasher_struct:ty) => {
+        #[cfg(feature = "std")]
         impl ::std::io::Write for $hasher_struct {
             fn write(&mut self, bytes: &[u8]) -> ::std::io::Result<usize> {
                 $crate::HighwayHash::append(self, bytes);

--- a/src/portable.rs
+++ b/src/portable.rs
@@ -3,7 +3,8 @@ use crate::key::Key;
 use crate::traits::HighwayHash;
 
 /// Portable HighwayHash implementation. Will run on any platform Rust will run on.
-#[derive(Debug, Default, Clone)]
+#[cfg_attr(feature = "std", derive(Debug))]
+#[derive(Default, Clone)]
 pub struct PortableHash {
     key: Key,
     buffer: HashPacket,
@@ -196,7 +197,7 @@ impl PortableHash {
     fn data_to_lanes(d: &[u8]) -> [u64; 4] {
         // Use of ptr::read_unaligned gave a 60% throughput increase for large payloads. I'm on the
         // lookout for a safe alternative that is as performant
-        debug_assert!(d.len() >= std::mem::size_of::<[u64; 4]>());
+        debug_assert!(d.len() >= core::mem::size_of::<[u64; 4]>());
         unsafe {
             [
                 (d.as_ptr().offset(0) as *const u64).read_unaligned(),

--- a/src/sse.rs
+++ b/src/sse.rs
@@ -3,11 +3,12 @@ use crate::internal::{Filled, HashPacket, PACKET_SIZE};
 use crate::key::Key;
 use crate::traits::HighwayHash;
 use crate::v2x64u::V2x64U;
-use std::arch::x86_64::*;
+use core::arch::x86_64::*;
 
 /// SSE empowered implementation that will only work on `x86_64` with sse 4.1 enabled at the CPU
 /// level.
-#[derive(Debug, Default, Clone)]
+#[cfg_attr(feature = "std", derive(Debug))]
+#[derive(Default, Clone)]
 pub struct SseHash {
     key: Key,
     buffer: HashPacket,
@@ -81,9 +82,18 @@ impl SseHash {
 
     /// Create a new `SseHash` if the sse4.1 feature is detected
     pub fn new(key: Key) -> Option<Self> {
-        if is_x86_feature_detected!("sse4.1") {
-            Some(unsafe { Self::force_new(key) })
-        } else {
+        #[cfg(feature = "std")]
+        {
+            if is_x86_feature_detected!("sse4.1") {
+                Some(unsafe { Self::force_new(key) })
+            } else {
+                None
+            }
+        }
+
+        #[cfg(not(feature = "std"))]
+        {
+            let _key = key;
             None
         }
     }

--- a/src/v2x64u.rs
+++ b/src/v2x64u.rs
@@ -1,6 +1,5 @@
-use std::arch::x86_64::*;
-use std::fmt;
-use std::ops::{
+use core::arch::x86_64::*;
+use core::ops::{
     Add, AddAssign, BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, ShlAssign,
     ShrAssign, SubAssign,
 };
@@ -14,8 +13,9 @@ impl Default for V2x64U {
     }
 }
 
-impl fmt::Debug for V2x64U {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+#[cfg(feature = "std")]
+impl std::fmt::Debug for V2x64U {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "V2x64U: {:?}", unsafe { self.to_arr() })
     }
 }
@@ -32,6 +32,7 @@ impl V2x64U {
     }
 
     #[target_feature(enable = "sse4.1")]
+    #[cfg(feature = "std")]
     unsafe fn to_arr(&self) -> [u64; 2] {
         let mut arr: [u64; 2] = [0, 0];
         _mm_storeu_si128(arr.as_mut_ptr() as *mut __m128i, self.0);

--- a/src/v4x64u.rs
+++ b/src/v4x64u.rs
@@ -1,7 +1,5 @@
-use std::arch::x86_64::*;
-
-use std::fmt;
-use std::ops::{
+use core::arch::x86_64::*;
+use core::ops::{
     Add, AddAssign, BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Shr, SubAssign,
 };
 
@@ -14,8 +12,9 @@ impl Default for V4x64U {
     }
 }
 
-impl fmt::Debug for V4x64U {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+#[cfg(feature = "std")]
+impl std::fmt::Debug for V4x64U {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "V4x64U: {:?}", unsafe { self.to_arr() })
     }
 }
@@ -43,6 +42,7 @@ impl V4x64U {
     }
 
     #[target_feature(enable = "avx2")]
+    #[cfg(feature = "std")]
     unsafe fn to_arr(&self) -> [u64; 4] {
         let mut arr: [u64; 4] = [0; 4];
         _mm256_storeu_si256(arr.as_mut_ptr() as *mut __m256i, self.0);

--- a/tests/highway-test.rs
+++ b/tests/highway-test.rs
@@ -494,20 +494,22 @@ fn sse_hash_eq_portable() {
 
     for i in 0..100 {
         println!("{}", i);
-        assert_eq!(
-            PortableHash::new(key).hash64(&data[..i]),
-            SseHash::new(key).expect("sse4.1").hash64(&data[..i])
-        );
+        unsafe {
+            assert_eq!(
+                PortableHash::new(key).hash64(&data[..i]),
+                SseHash::force_new(key).hash64(&data[..i])
+            );
 
-        assert_eq!(
-            PortableHash::new(key).hash128(&data[..i]),
-            SseHash::new(key).expect("sse4.1").hash128(&data[..i])
-        );
+            assert_eq!(
+                PortableHash::new(key).hash128(&data[..i]),
+                SseHash::force_new(key).hash128(&data[..i])
+            );
 
-        assert_eq!(
-            PortableHash::new(key).hash256(&data[..i]),
-            SseHash::new(key).expect("sse4.1").hash256(&data[..i])
-        );
+            assert_eq!(
+                PortableHash::new(key).hash256(&data[..i]),
+                SseHash::force_new(key).hash256(&data[..i])
+            );
+        }
     }
 }
 
@@ -529,20 +531,22 @@ fn avx_hash_eq_portable() {
 
     for i in 0..100 {
         println!("{}", i);
-        assert_eq!(
-            PortableHash::new(key).hash64(&data[..i]),
-            AvxHash::new(key).expect("avx2").hash64(&data[..i])
-        );
+        unsafe {
+            assert_eq!(
+                PortableHash::new(key).hash64(&data[..i]),
+                AvxHash::force_new(key).hash64(&data[..i])
+            );
 
-        assert_eq!(
-            PortableHash::new(key).hash128(&data[..i]),
-            AvxHash::new(key).expect("avx2").hash128(&data[..i])
-        );
+            assert_eq!(
+                PortableHash::new(key).hash128(&data[..i]),
+                AvxHash::force_new(key).hash128(&data[..i])
+            );
 
-        assert_eq!(
-            PortableHash::new(key).hash256(&data[..i]),
-            AvxHash::new(key).expect("avx2").hash256(&data[..i])
-        );
+            assert_eq!(
+                PortableHash::new(key).hash256(&data[..i]),
+                AvxHash::force_new(key).hash256(&data[..i])
+            );
+        }
     }
 }
 
@@ -562,9 +566,7 @@ fn avx_survive_crash() {
     }
 
     let data = include_bytes!("../assets/avx-crash-1");
-    let hash = AvxHash::new(Key([1, 2, 3, 4]))
-        .expect("avx2")
-        .hash64(&data[..]);
+    let hash = unsafe { AvxHash::force_new(Key([1, 2, 3, 4])) }.hash64(&data[..]);
     assert!(hash != 0);
 }
 

--- a/tests/traits.rs
+++ b/tests/traits.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "std")]
+
 fn hash<H>() -> std::io::Result<u64>
 where
     H: std::hash::Hasher,


### PR DESCRIPTION
By adding a default feature of "std" this is a backwards compatible
change that allows highway-rs to be built without the standard library
if one disables all features.

No APIs are changed in the process (other than std APIs like Debug or
Write). There is a behavior change when determining the best
implementation: since CPU detection is not available to `no_std` the
builder will always choose the portal implementation, so users who want
to use SSE 4.2 or AVX 2 will need to explicitly construct them with
`force_new` and the associated risk with calling them.

Closes #32 