### PR TITLE
Re-enable Debug trait impls on no_std

### DIFF
--- a/src/avx.rs
+++ b/src/avx.rs
@@ -8,8 +8,7 @@ use core::arch::x86_64::*;
 
 /// AVX empowered implementation that will only work on `x86_64` with avx2 enabled at the CPU
 /// level.
-#[cfg_attr(feature = "std", derive(Debug))]
-#[derive(Default, Clone)]
+#[derive(Debug, Default, Clone)]
 pub struct AvxHash {
     key: Key,
     buffer: HashPacket,

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -8,8 +8,7 @@ use crate::avx::AvxHash;
 #[cfg(target_arch = "x86_64")]
 use crate::sse::SseHash;
 
-#[cfg_attr(feature = "std", derive(Debug))]
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 enum HighwayChoices {
     Portable(PortableHash),
     #[cfg(target_arch = "x86_64")]
@@ -26,8 +25,7 @@ enum HighwayChoices {
 ///  - AvxHash
 ///  - SseHash
 ///  - PortableHash
-#[cfg_attr(feature = "std", derive(Debug))]
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct HighwayBuilder(HighwayChoices);
 
 impl HighwayHash for HighwayBuilder {

--- a/src/portable.rs
+++ b/src/portable.rs
@@ -3,8 +3,7 @@ use crate::key::Key;
 use crate::traits::HighwayHash;
 
 /// Portable HighwayHash implementation. Will run on any platform Rust will run on.
-#[cfg_attr(feature = "std", derive(Debug))]
-#[derive(Default, Clone)]
+#[derive(Debug, Default, Clone)]
 pub struct PortableHash {
     key: Key,
     buffer: HashPacket,

--- a/src/sse.rs
+++ b/src/sse.rs
@@ -7,8 +7,7 @@ use core::arch::x86_64::*;
 
 /// SSE empowered implementation that will only work on `x86_64` with sse 4.1 enabled at the CPU
 /// level.
-#[cfg_attr(feature = "std", derive(Debug))]
-#[derive(Default, Clone)]
+#[derive(Debug, Default, Clone)]
 pub struct SseHash {
     key: Key,
     buffer: HashPacket,

--- a/src/v2x64u.rs
+++ b/src/v2x64u.rs
@@ -13,9 +13,8 @@ impl Default for V2x64U {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::fmt::Debug for V2x64U {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for V2x64U {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "V2x64U: {:?}", unsafe { self.to_arr() })
     }
 }
@@ -32,7 +31,6 @@ impl V2x64U {
     }
 
     #[target_feature(enable = "sse4.1")]
-    #[cfg(feature = "std")]
     unsafe fn to_arr(&self) -> [u64; 2] {
         let mut arr: [u64; 2] = [0, 0];
         _mm_storeu_si128(arr.as_mut_ptr() as *mut __m128i, self.0);

--- a/src/v4x64u.rs
+++ b/src/v4x64u.rs
@@ -12,9 +12,8 @@ impl Default for V4x64U {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::fmt::Debug for V4x64U {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for V4x64U {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "V4x64U: {:?}", unsafe { self.to_arr() })
     }
 }
@@ -42,7 +41,6 @@ impl V4x64U {
     }
 
     #[target_feature(enable = "avx2")]
-    #[cfg(feature = "std")]
     unsafe fn to_arr(&self) -> [u64; 4] {
         let mut arr: [u64; 4] = [0; 4];
         _mm256_storeu_si256(arr.as_mut_ptr() as *mut __m256i, self.0);


### PR DESCRIPTION
I mistakenly thought `std::fmt` wasn't available on core -- but it turns
out it is available.