### PR TITLE
Simplify HighwayHash implementation with shared trait methods

### DIFF
--- a/src/avx.rs
+++ b/src/avx.rs
@@ -19,27 +19,6 @@ pub struct AvxHash {
 }
 
 impl HighwayHash for AvxHash {
-    fn hash64(mut self, data: &[u8]) -> u64 {
-        unsafe {
-            self.append(data);
-            self.finalize64()
-        }
-    }
-
-    fn hash128(mut self, data: &[u8]) -> [u64; 2] {
-        unsafe {
-            self.append(data);
-            self.finalize128()
-        }
-    }
-
-    fn hash256(mut self, data: &[u8]) -> [u64; 4] {
-        unsafe {
-            self.append(data);
-            self.finalize256()
-        }
-    }
-
     fn append(&mut self, data: &[u8]) {
         unsafe {
             self.append(data);

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -22,36 +22,6 @@ enum HighwayChoices {
 pub struct HighwayBuilder(HighwayChoices);
 
 impl HighwayHash for HighwayBuilder {
-    fn hash64(self, data: &[u8]) -> u64 {
-        match self.0 {
-            HighwayChoices::Portable(x) => x.hash64(data),
-            #[cfg(target_arch = "x86_64")]
-            HighwayChoices::Avx(x) => x.hash64(data),
-            #[cfg(target_arch = "x86_64")]
-            HighwayChoices::Sse(x) => x.hash64(data),
-        }
-    }
-
-    fn hash128(self, data: &[u8]) -> [u64; 2] {
-        match self.0 {
-            HighwayChoices::Portable(x) => x.hash128(data),
-            #[cfg(target_arch = "x86_64")]
-            HighwayChoices::Avx(x) => x.hash128(data),
-            #[cfg(target_arch = "x86_64")]
-            HighwayChoices::Sse(x) => x.hash128(data),
-        }
-    }
-
-    fn hash256(self, data: &[u8]) -> [u64; 4] {
-        match self.0 {
-            HighwayChoices::Portable(x) => x.hash256(data),
-            #[cfg(target_arch = "x86_64")]
-            HighwayChoices::Avx(x) => x.hash256(data),
-            #[cfg(target_arch = "x86_64")]
-            HighwayChoices::Sse(x) => x.hash256(data),
-        }
-    }
-
     fn append(&mut self, data: &[u8]) {
         match &mut self.0 {
             HighwayChoices::Portable(x) => x.append(data),

--- a/src/portable.rs
+++ b/src/portable.rs
@@ -14,21 +14,6 @@ pub struct PortableHash {
 }
 
 impl HighwayHash for PortableHash {
-    fn hash64(mut self, data: &[u8]) -> u64 {
-        self.append(data);
-        self.finalize64()
-    }
-
-    fn hash128(mut self, data: &[u8]) -> [u64; 2] {
-        self.append(data);
-        self.finalize128()
-    }
-
-    fn hash256(mut self, data: &[u8]) -> [u64; 4] {
-        self.append(data);
-        self.finalize256()
-    }
-
     fn append(&mut self, data: &[u8]) {
         self.append(data);
     }

--- a/src/sse.rs
+++ b/src/sse.rs
@@ -22,27 +22,6 @@ pub struct SseHash {
 }
 
 impl HighwayHash for SseHash {
-    fn hash64(mut self, data: &[u8]) -> u64 {
-        unsafe {
-            self.append(data);
-            self.finalize64()
-        }
-    }
-
-    fn hash128(mut self, data: &[u8]) -> [u64; 2] {
-        unsafe {
-            self.append(data);
-            self.finalize128()
-        }
-    }
-
-    fn hash256(mut self, data: &[u8]) -> [u64; 4] {
-        unsafe {
-            self.append(data);
-            self.finalize256()
-        }
-    }
-
     fn append(&mut self, data: &[u8]) {
         unsafe {
             self.append(data);

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,16 +1,25 @@
 /// The common set of methods for hashing data.
-pub trait HighwayHash {
+pub trait HighwayHash: Sized {
     /// Convenience function for hashing all data in a single call and receiving a 64bit hash.
     /// Results are equivalent to appending the data manually.
-    fn hash64(self, data: &[u8]) -> u64;
+    fn hash64(mut self, data: &[u8]) -> u64 {
+        self.append(data);
+        self.finalize64()
+    }
 
     /// Convenience function for hashing all data in a single call and receiving a 128bit hash.
     /// Results are equivalent to appending the data manually.
-    fn hash128(self, data: &[u8]) -> [u64; 2];
+    fn hash128(mut self, data: &[u8]) -> [u64; 2] {
+        self.append(data);
+        self.finalize128()
+    }
 
     /// Convenience function for hashing all data in a single call and receiving a 256bit hash.
     /// Results are equivalent to appending the data manually.
-    fn hash256(self, data: &[u8]) -> [u64; 4];
+    fn hash256(mut self, data: &[u8]) -> [u64; 4] {
+        self.append(data);
+        self.finalize256()
+    }
 
     /// Adds data to be hashed. If it is important, the performance characteristics of this
     /// function differs depending on the amount of data previously hashed and the amount of


### PR DESCRIPTION
Instead of having each implementation redefine the convenience
functions, implement at the trait level