### PR TITLE
Remove unsafe from portable implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ function.
  - ✔ zero dependencies
  - ✔ generate 64, 128, and 256bit hashes
  - ✔ > 10 GB/s with SIMD (SSE 4.1 & AVX 2) aware instructions on x86 architectures
- - ✔ > 1 GB/s portable implementation with only one instance of `unsafe`
+ - ✔ > 1 GB/s portable implementation with zero unsafe code
  - ✔ passes reference test suite
  - ✔ incremental / streaming hashes
  - ✔ zero heap allocations

--- a/src/portable.rs
+++ b/src/portable.rs
@@ -179,17 +179,11 @@ impl PortableHash {
     }
 
     fn data_to_lanes(d: &[u8]) -> [u64; 4] {
-        // Use of ptr::read_unaligned gave a 60% throughput increase for large payloads. I'm on the
-        // lookout for a safe alternative that is as performant
-        debug_assert!(d.len() >= core::mem::size_of::<[u64; 4]>());
-        unsafe {
-            [
-                (d.as_ptr().offset(0) as *const u64).read_unaligned().to_le(),
-                (d.as_ptr().offset(8) as *const u64).read_unaligned().to_le(),
-                (d.as_ptr().offset(16) as *const u64).read_unaligned().to_le(),
-                (d.as_ptr().offset(24) as *const u64).read_unaligned().to_le(),
-            ]
+        let mut result = [0u64; 4];
+        for (i, x) in d.chunks_exact(8).take(result.len()).enumerate() {
+            result[i] = u64::from_le_bytes([x[0], x[1], x[2], x[3], x[4], x[5], x[6], x[7]]);
         }
+        result
     }
 
     fn rotate_32_by(count: u64, lanes: &mut [u64; 4]) {


### PR DESCRIPTION
Converting a byte slice to 4 u64's is a hot path, so unsafe was used to
read unaligned pointers causing a 60% throughput increase.

I fiddled around today and found the following safe code benchmarked
within margin of error, so now the portable implementation can be
completely safe!

As for why

```rust
let mut result = [0u64; 4];
for (i, x) in d.chunks_exact(8).take(result.len()).enumerate() {
    result[i] = u64::from_le_bytes([x[0], x[1], x[2], x[3], x[4], x[5], x[6], x[7]]);
}
result
```

is so much faster than:

```rust
[
    u64::from_le_bytes([d[0], d[1], d[2], d[3], d[4], d[5], d[6], d[7]]),
    u64::from_le_bytes([d[8], d[9], d[10], d[11], d[12], d[13], d[14], d[15]]),
    u64::from_le_bytes([d[16], d[17], d[18], d[19], d[20], d[21], d[22], d[23]]),
    u64::from_le_bytes([d[24], d[25], d[26], d[27], d[28], d[29], d[30], d[31]]),
]
```

Looking at the assembly output, the old version is doing a bounds check
for each access whereas the new version does zero bounds checking. Turns
out bounds checking is expensive!

I'm a tad worry that relying on the compiler to elide bounds checks in
for this scenario could regress at some point in the future but it seems
like a worthwhile risk to remove the last vestiges of unsafe.