### PR TITLE
V4x64U: switch from a `Shr` impl to a dedicated function

### DIFF
--- a/src/avx.rs
+++ b/src/avx.rs
@@ -214,9 +214,9 @@ impl AvxHash {
     unsafe fn update(&mut self, packet: V4x64U) {
         self.v1 += packet;
         self.v1 += self.mul0;
-        self.mul0 ^= self.v1.mul_low32(&(self.v0 >> 32));
+        self.mul0 ^= self.v1.mul_low32(&self.v0.shr_by_32());
         self.v0 += self.mul1;
-        self.mul1 ^= self.v0.mul_low32(&(self.v1 >> 32));
+        self.mul1 ^= self.v0.mul_low32(&self.v1.shr_by_32());
         self.v0 += AvxHash::zipper_merge(&self.v1);
         self.v1 += AvxHash::zipper_merge(&self.v0);
     }

--- a/src/v4x64u.rs
+++ b/src/v4x64u.rs
@@ -1,6 +1,6 @@
 use core::arch::x86_64::*;
 use core::ops::{
-    Add, AddAssign, BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Shr, SubAssign,
+    Add, AddAssign, BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, SubAssign,
 };
 
 #[derive(Clone, Copy)]
@@ -50,6 +50,11 @@ impl V4x64U {
     #[target_feature(enable = "avx2")]
     pub unsafe fn rotate_by_32(&self) -> Self {
         V4x64U(_mm256_shuffle_epi32(self.0, _mm_shuffle!(2, 3, 0, 1)))
+    }
+
+    #[target_feature(enable = "avx2")]
+    pub unsafe fn shr_by_32(&self) -> Self {
+        V4x64U(_mm256_srli_epi64(self.0, 32))
     }
 
     #[target_feature(enable = "avx2")]
@@ -163,16 +168,6 @@ impl BitXor for V4x64U {
     fn bitxor(self, other: Self) -> Self {
         let mut new = V4x64U(self.0);
         new ^= other;
-        new
-    }
-}
-
-impl Shr<i32> for V4x64U {
-    type Output = Self;
-
-    fn shr(self, shift: i32) -> Self {
-        let mut new = V4x64U(self.0);
-        unsafe { new.0 = _mm256_srli_epi64(self.0, shift) }
         new
     }
 }


### PR DESCRIPTION
Hi, rust contributor over here 👋.

Your crate came up in the [results of a crater run](https://github.com/rust-lang/rust/pull/83278#issuecomment-821444240) updating a part of `libcore`: [`stdarch`](https://github.com/rust-lang/stdarch), and this PR should fix that.

For context, we're trying to update `libcore`'s `stdarch` to improve handling of immediate mode arguments (tracking issue: https://github.com/rust-lang/stdarch/issues/248): the current solution is suboptimal. It uses macros to ensure the immediate arguments are indeed constants, and that causes problems (the size of `libcore` and the time it takes to compile). 

Now that const generics are available, we're trying to move from the previous way of doing things to using const generics, so that non-constant immediates cause a compile error instead: 
- rustc was updated to add a mechanism to keep the unexpectedly stable intrinsics using the old method working
- the intrinsics in `stdarch` were updated (tracking issue for this effort: https://github.com/rust-lang/stdarch/issues/1022)
- this revision of `stdarch` is currently being tested in crater, via the https://github.com/rust-lang/rust/pull/83278 PR.

(There is also more discussion around this topic in https://github.com/rust-lang/rust/issues/83167 if that interests you, but it is more about the best way to keep existing code working, whether a switch to const generics should be done over an edition, and so on.)

Overall, `highway-rs` would stop compiling if that PR above were to be merged:
- the `Shr` impl of `V4x64U` uses the `_mm256_srli_epi64` intrinsic, and it appears it was stabilized without the `#[rustc_args_required_const]` attribute. That should have ensured the immediate is a constant.
- with the switch to const generics, this impl now fails to compile: the shift amount is a runtime variable. Thankfully `AvxHash::update` only uses it with the constant 32.

So, this PR removes the `Shr` impl, and adds a method to do the shift-right-by-32 instead (and `V4x64U` is not public API IIUC, so it should not be a breaking change).

I've ran the tests in this crate using the rustc CI artifacts from that PR: thanks to [`rustup-toolchain-install-master`](https://github.com/kennytm/rustup-toolchain-install-master), with the `9cae4dca0b4ddbfe82616f4d5f1090fc817e2ffa` rustc CI revision.

Note: if you wish to retain the `Shr` impl, it still is possible to do so using the same trick that `stdarch` removed, via manual monomorphization of the runtime shift amount with a macro. For example, this is what is done in the `simdeez` crate, [here](https://github.com/jackmott/simdeez/blob/796ac4d7817f066b5ccc2a7b11fdca67d83da192/src/avx2/overloads.rs#L556-L568) (just with a different width and intrinsic). Doing that once, for the only argument 32, would be a different solution than this PR proposes, to keep the crate compiling.