### PR TITLE
Make WasmHash::new infallible

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,9 +142,8 @@ Then the `WasmHash` struct becomes available.
 ```rust,ignore
 use highway::{HighwayHash, Key, WasmHash};
 let key = Key([0, 0, 0, 0]);
-if let Some(hasher) = WasmHash::new(key) {
-  let result = hasher.hash64(&[]);
-}
+let hasher = WasmHash::new(key);
+let result = hasher.hash64(&[]);
 ```
 
 Once opted in, the execution environment must support Wasm SIMD instructions, which Chrome, Firefox, and Node LTS have stabilized since mid-2021. The opt in is required as there is not a way for Wasm to detect SIMD capabilities at runtime.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,9 +136,8 @@ Then the `WasmHash` struct becomes available.
 ```rust,ignore
 use highway::{HighwayHash, Key, WasmHash};
 let key = Key([0, 0, 0, 0]);
-if let Some(hasher) = WasmHash::new(key) {
-  let result = hasher.hash64(&[]);
-}
+let hasher = WasmHash::new(key);
+let result = hasher.hash64(&[]);
 ```
 
 Once opted in, the execution environment must support Wasm SIMD instructions, which Chrome, Firefox, and Node LTS have stabilized since mid-2021. The opt in is required as there is not a way for Wasm to detect SIMD capabilities at runtime.

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -41,18 +41,13 @@ impl HighwayHash for WasmHash {
 
 impl WasmHash {
     /// Creates a new `WasmHash` based on Wasm SIMD extension
-    pub fn force_new(key: Key) -> Self {
+    pub fn new(key: Key) -> Self {
         let mut h = WasmHash {
             key,
             ..Default::default()
         };
         h.reset();
         h
-    }
-
-    /// Create a new `WasmHash` if the sse4.1 feature is detected
-    pub fn new(key: Key) -> Option<Self> {
-        Some(Self::force_new(key))
     }
 
     fn reset(&mut self) {

--- a/tests/wasm.rs
+++ b/tests/wasm.rs
@@ -5,7 +5,7 @@ use wasm_bindgen_test::*;
 #[wasm_bindgen_test]
 fn hash_zeroes() {
     let key = Key([0, 0, 0, 0]);
-    let hash = WasmHash::new(key).unwrap().hash64(&[]);
+    let hash = WasmHash::new(key).hash64(&[]);
     assert_eq!(0x7035_DA75_B9D5_4469, hash);
 }
 
@@ -13,7 +13,7 @@ fn hash_zeroes() {
 fn hash_simple() {
     let key = Key([1, 2, 3, 4]);
     let b: Vec<u8> = (0..33).map(|x| 128 + x as u8).collect();
-    let hash = WasmHash::new(key).unwrap().hash64(&b[..]);
+    let hash = WasmHash::new(key).hash64(&b[..]);
     assert_eq!(0x53c5_16cc_e478_cad7, hash);
 }
 
@@ -29,17 +29,17 @@ fn wasm_eq_portable() {
 
     for i in 0..data.len() {
         assert_eq!(
-            WasmHash::new(key).unwrap().hash64(&data[..i]),
+            WasmHash::new(key).hash64(&data[..i]),
             PortableHash::new(key).hash64(&data[..i])
         );
 
         assert_eq!(
-            WasmHash::new(key).unwrap().hash128(&data[..i]),
+            WasmHash::new(key).hash128(&data[..i]),
             PortableHash::new(key).hash128(&data[..i])
         );
 
         assert_eq!(
-            WasmHash::new(key).unwrap().hash256(&data[..i]),
+            WasmHash::new(key).hash256(&data[..i]),
             PortableHash::new(key).hash256(&data[..i])
         );
     }


### PR DESCRIPTION
The mere presence of Wasm SIMD instructions will cause older Wasm
compilers to fail even if the Wasm SIMD instruction is never executed.
With that huge caveat, feature detection inside Wasm will not be until
an inordinate amount of time has passed, as first feature detection
needs to be implemented and then we must wait until the runtimes without
feature detections fall out of use.

Since I do not want to give the impression that feature detection is
available with the `Option` return on `WasmHash::new`, it has been
changed to always be infallible.