### PR TITLE
Enable HighwayHasher implementation to use Wasm SIMD

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,16 +137,9 @@ When deploying HighwayHash to a Wasm environment, one can opt into using the Was
 RUSTFLAGS="-C target-feature=+simd128" wasm-pack build
 ```
 
-Then the `WasmHash` struct becomes available.
+Then `HighwayHasher` will automatically defer to the Wasm SIMD implementation via `WasmHash`.
 
-```rust,ignore
-use highway::{HighwayHash, Key, WasmHash};
-let key = Key([0, 0, 0, 0]);
-let hasher = WasmHash::new(key);
-let result = hasher.hash64(&[]);
-```
-
-Once opted in, the execution environment must support Wasm SIMD instructions, which Chrome, Firefox, and Node LTS have stabilized since mid-2021. The opt in is required as there is not a way for Wasm to detect SIMD capabilities at runtime.
+Once opted in, the execution environment must support Wasm SIMD instructions, which Chrome, Firefox, and Node LTS have stabilized since mid-2021. The opt in is required as there is not a way for Wasm to detect SIMD capabilities at runtime. The mere presence of Wasm SIMD instructions will cause incompatible environments to fail to compile, so it is recommended to provide two Wasm payloads to downstream users: one with SIMD enabled and one without.
 
 ## Use Cases
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,16 +131,9 @@ When deploying HighwayHash to a Wasm environment, one can opt into using the Was
 RUSTFLAGS="-C target-feature=+simd128" wasm-pack build
 ```
 
-Then the `WasmHash` struct becomes available.
+Then `HighwayHasher` will automatically defer to the Wasm SIMD implementation via `WasmHash`.
 
-```rust,ignore
-use highway::{HighwayHash, Key, WasmHash};
-let key = Key([0, 0, 0, 0]);
-let hasher = WasmHash::new(key);
-let result = hasher.hash64(&[]);
-```
-
-Once opted in, the execution environment must support Wasm SIMD instructions, which Chrome, Firefox, and Node LTS have stabilized since mid-2021. The opt in is required as there is not a way for Wasm to detect SIMD capabilities at runtime.
+Once opted in, the execution environment must support Wasm SIMD instructions, which Chrome, Firefox, and Node LTS have stabilized since mid-2021. The opt in is required as there is not a way for Wasm to detect SIMD capabilities at runtime. The mere presence of Wasm SIMD instructions will cause incompatible environments to fail to compile, so it is recommended to provide two Wasm payloads to downstream users: one with SIMD enabled and one without.
 
 ## Use Cases
 

--- a/tests/hash.rs
+++ b/tests/hash.rs
@@ -1,4 +1,4 @@
-use highway::{HighwayHash, Key, PortableHash};
+use highway::{HighwayHash, HighwayHasher, Key, PortableHash};
 
 #[test]
 fn hash_zeroes() {
@@ -41,8 +41,7 @@ fn portable_hash_append2() {
     assert_eq!(0x7858_f24d_2d79_b2b2, hash);
 }
 
-#[test]
-fn portable_hash_all() {
+pub fn hash_all() {
     let expected64 = [
         0x907A_56DE_22C2_6E53,
         0x7EAB_43AA_C7CD_DD78,
@@ -451,28 +450,33 @@ fn portable_hash_all() {
 
     for i in 0..64 {
         println!("{}", i);
-        let res_128 = u64_to_u128(&PortableHash::new(key).hash128(&data[..i])[..]);
-        let res_256 = u64_to_u256(&PortableHash::new(key).hash256(&data[..i])[..]);
-        assert_eq!(expected64[i], PortableHash::new(key).hash64(&data[..i]));
+        let res_128 = u64_to_u128(&HighwayHasher::new(key).hash128(&data[..i])[..]);
+        let res_256 = u64_to_u256(&HighwayHasher::new(key).hash256(&data[..i])[..]);
+        assert_eq!(expected64[i], HighwayHasher::new(key).hash64(&data[..i]));
         assert_eq!(expected128[i], res_128);
         assert_eq!(expected256[i], res_256);
 
         assert_eq!(expected64[i], {
-            let mut hasher = PortableHash::new(key);
+            let mut hasher = HighwayHasher::new(key);
             hasher.append(&data[..i]);
             hasher.finalize64()
         });
         assert_eq!(expected128[i], {
-            let mut hasher = PortableHash::new(key);
+            let mut hasher = HighwayHasher::new(key);
             hasher.append(&data[..i]);
             u64_to_u128(&hasher.finalize128()[..])
         });
         assert_eq!(expected256[i], {
-            let mut hasher = PortableHash::new(key);
+            let mut hasher = HighwayHasher::new(key);
             hasher.append(&data[..i]);
             u64_to_u256(&hasher.finalize256()[..])
         });
     }
+}
+
+#[test]
+fn test_hash_all() {
+    hash_all();
 }
 
 fn u64_to_u128(data: &[u64]) -> u128 {

--- a/tests/wasm.rs
+++ b/tests/wasm.rs
@@ -2,6 +2,8 @@
 use highway::{HighwayHash, Key, PortableHash, WasmHash};
 use wasm_bindgen_test::*;
 
+mod hash;
+
 #[wasm_bindgen_test]
 fn hash_zeroes() {
     let key = Key([0, 0, 0, 0]);
@@ -43,4 +45,9 @@ fn wasm_eq_portable() {
             PortableHash::new(key).hash256(&data[..i])
         );
     }
+}
+
+#[wasm_bindgen_test]
+fn wasm_hash_all() {
+    hash::hash_all();
 }


### PR DESCRIPTION
This makes writing libraries easier as one should just use the
`HighwayHasher` type and that will automatically opt into the Wasm SIMD
implementation when a downstream developer enables it