### PR TITLE
Detect AVX on no_std when compiled for it

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -133,3 +133,16 @@ jobs:
 
     - name: Run tests (with SIMD)
       run: RUSTFLAGS="-C target-feature=+simd128" wasm-pack test --node -- --verbose
+
+  instructions:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        feature: ["-sse4.1,-avx2", "-sse4.1,+avx2", "+sse4.1,+avx2", "+sse4.1,-avx2"]
+    steps:
+    - uses: actions/checkout@v1
+    - name: Test
+      run: RUSTFLAGS="-C target-feature=${{matrix.feature}}" cargo test --verbose
+    - name: No Std Tests
+      run: RUSTFLAGS="-C target-feature=${{matrix.feature}}" cargo test --no-default-features --verbose

--- a/README.md
+++ b/README.md
@@ -160,7 +160,12 @@ in a `no_std` context, add the following to your `Cargo.toml`:
 highway = { version = "x", default-features = false }
 ```
 
-Be aware that the `no_std` version is unable to detect CPU features and so will always default to the portable implementation. If building for a known SSE 4.1 or AVX 2 machine (and the majority of machines in the last decade will support SSE 4.1), these hashers can still be constructed with `force_new`.
+Be aware that the `no_std` version is unable to detect CPU features and so will always default to the portable implementation. If building for a known SSE 4.1 or AVX 2 machine (and the majority of machines in the last decade will support SSE 4.1), then explicitly enable the target feature:
+
+```bash
+RUSTFLAGS="-C target-feature=+sse4.1" cargo test
+RUSTFLAGS="-C target-feature=+avx2" cargo test
+```
 
 ## Benchmarks
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -146,15 +146,12 @@ HighwayHash may not be a good fit if the payloads trend small (< 100 bytes) and 
 
 ### `no_std` crates
 
-This crate has a feature, `std`, that is enabled by default. To use this crate
-in a `no_std` context, add the following to your `Cargo.toml`:
+Be aware that the `no_std` version is unable to detect CPU features and so will always default to the portable implementation. If building for a known SSE 4.1 or AVX 2 machine (and the majority of machines in the last decade will support SSE 4.1), then explicitly enable the target feature:
 
-```toml
-[dependencies]
-highway = { version = "x", default-features = false }
+```bash
+RUSTFLAGS="-C target-feature=+sse4.1" cargo test
+RUSTFLAGS="-C target-feature=+avx2" cargo test
 ```
-
-Be aware that the `no_std` version is unable to detect CPU features and so will always default to the portable implementation. If building for a known SSE 4.1 or AVX 2 machine (and the majority of machines in the last decade will support SSE 4.1), these hashers can still be constructed with `force_new`.
 
 */
 #![allow(non_snake_case)]


### PR DESCRIPTION
Currently the no_std implementation always chooses the portable
implementation. This PR fixes this by detecting if the downstream user
explicitly compiled in support for sse4.1 or avx2.