### PR TITLE
Add aarch64 neon support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,10 +30,11 @@ jobs:
         - macos
         - win-msvc
         - win-gnu
+        - aarch64-unknown-linux-gnu
         include:
         - build: pinned
           os: ubuntu-latest
-          rust: 1.54.0
+          rust: 1.59.0
         - build: stable
           os: ubuntu-latest
           rust: stable
@@ -60,6 +61,10 @@ jobs:
         - build: win-gnu
           os: windows-latest
           rust: stable-x86_64-gnu
+        - build: aarch64-unknown-linux-gnu
+          os: ubuntu-latest
+          rust: stable
+          target: aarch64-unknown-linux-gnu
     steps:
     - name: Checkout repository
       uses: actions/checkout@v1

--- a/src/aarch64.rs
+++ b/src/aarch64.rs
@@ -1,0 +1,482 @@
+use crate::internal::{unordered_load3, Filled, HashPacket, PACKET_SIZE};
+use crate::{HighwayHash, Key};
+use core::arch::aarch64::*;
+use core::ops::{
+    Add, AddAssign, BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, SubAssign,
+};
+
+/// HighwayHash powered by Neon instructions
+#[derive(Debug, Default, Clone)]
+pub struct NeonHash {
+    key: Key,
+    buffer: HashPacket,
+    v0L: V2x64U,
+    v0H: V2x64U,
+    v1L: V2x64U,
+    v1H: V2x64U,
+    mul0L: V2x64U,
+    mul0H: V2x64U,
+    mul1L: V2x64U,
+    mul1H: V2x64U,
+}
+
+impl HighwayHash for NeonHash {
+    fn append(&mut self, data: &[u8]) {
+        unsafe {
+            self.append(data);
+        }
+    }
+
+    fn finalize64(mut self) -> u64 {
+        unsafe { Self::finalize64(&mut self) }
+    }
+
+    fn finalize128(mut self) -> [u64; 2] {
+        unsafe { Self::finalize128(&mut self) }
+    }
+
+    fn finalize256(mut self) -> [u64; 4] {
+        unsafe { Self::finalize256(&mut self) }
+    }
+}
+
+impl NeonHash {
+    /// Creates a new `NeonHash` while circumventing any runtime checks.
+    pub unsafe fn force_new(key: Key) -> Self {
+        let mut h = NeonHash {
+            key,
+            ..Default::default()
+        };
+        h.reset();
+        h
+    }
+
+    unsafe fn reset(&mut self) {
+        let init0L = V2x64U::new(0xa409_3822_299f_31d0, 0xdbe6_d5d5_fe4c_ce2f);
+        let init0H = V2x64U::new(0x243f_6a88_85a3_08d3, 0x1319_8a2e_0370_7344);
+        let init1L = V2x64U::new(0xc0ac_f169_b5f1_8a8c, 0x3bd3_9e10_cb0e_f593);
+        let init1H = V2x64U::new(0x4528_21e6_38d0_1377, 0xbe54_66cf_34e9_0c6c);
+        let keyL = V2x64U::new(self.key.0[1], self.key.0[0]);
+        let keyH = V2x64U::new(self.key.0[3], self.key.0[2]);
+        self.v0L = keyL ^ init0L;
+        self.v0H = keyH ^ init0H;
+        self.v1L = keyL.rotate_by_32() ^ init1L;
+        self.v1H = keyH.rotate_by_32() ^ init1H;
+        self.mul0L = init0L;
+        self.mul0H = init0H;
+        self.mul1L = init1L;
+        self.mul1H = init1H;
+    }
+
+    unsafe fn zipper_merge(v: &V2x64U) -> V2x64U {
+        let pos = [3, 12, 2, 5, 14, 1, 15, 0, 11, 4, 10, 13, 9, 6, 8, 7];
+        let tbl = vld1q_u8(pos.as_ptr());
+        let lookup = vqtbl1q_u8(vreinterpretq_u8_u64(v.0), tbl);
+        V2x64U::from(lookup)
+    }
+
+    unsafe fn update(&mut self, packetH: V2x64U, packetL: V2x64U) {
+        self.v1L += packetL;
+        self.v1H += packetH;
+        self.v1L += self.mul0L;
+        self.v1H += self.mul0H;
+        self.mul0L ^= V2x64U(vmull_u32(
+            vmovn_u64(self.v1L.0),
+            vshrn_n_u64(self.v0L.0, 32),
+        ));
+        self.mul0H ^= V2x64U(vmull_u32(
+            vmovn_u64(self.v1H.0),
+            vshrn_n_u64(self.v0H.0, 32),
+        ));
+        self.v0L += self.mul1L;
+        self.v0H += self.mul1H;
+        self.mul1L ^= V2x64U(vmull_u32(
+            vmovn_u64(self.v0L.0),
+            vshrn_n_u64(self.v1L.0, 32),
+        ));
+        self.mul1H ^= V2x64U(vmull_u32(
+            vmovn_u64(self.v0H.0),
+            vshrn_n_u64(self.v1H.0, 32),
+        ));
+        self.v0L += NeonHash::zipper_merge(&self.v1L);
+        self.v0H += NeonHash::zipper_merge(&self.v1H);
+        self.v1L += NeonHash::zipper_merge(&self.v0L);
+        self.v1H += NeonHash::zipper_merge(&self.v0H);
+    }
+
+    unsafe fn permute_and_update(&mut self) {
+        let low = self.v0L.rotate_by_32();
+        let high = self.v0H.rotate_by_32();
+        self.update(low, high);
+    }
+
+    unsafe fn finalize64(&mut self) -> u64 {
+        if !self.buffer.is_empty() {
+            self.update_remainder();
+        }
+
+        for _i in 0..4 {
+            self.permute_and_update();
+        }
+
+        let sum0 = self.v0L + self.mul0L;
+        let sum1 = self.v1L + self.mul1L;
+        let hash = sum0 + sum1;
+        hash.as_arr()[0]
+    }
+
+    unsafe fn finalize128(&mut self) -> [u64; 2] {
+        if !self.buffer.is_empty() {
+            self.update_remainder();
+        }
+
+        for _i in 0..6 {
+            self.permute_and_update();
+        }
+
+        let sum0 = self.v0L + self.mul0L;
+        let sum1 = self.v1H + self.mul1H;
+        let hash = sum0 + sum1;
+        hash.as_arr()
+    }
+
+    unsafe fn finalize256(&mut self) -> [u64; 4] {
+        if !self.buffer.is_empty() {
+            self.update_remainder();
+        }
+
+        for _i in 0..10 {
+            self.permute_and_update();
+        }
+
+        let sum0L = self.v0L + self.mul0L;
+        let sum1L = self.v1L + self.mul1L;
+        let sum0H = self.v0H + self.mul0H;
+        let sum1H = self.v1H + self.mul1H;
+
+        let hashL = NeonHash::modular_reduction(&sum1L, &sum0L).as_arr();
+        let hashH = NeonHash::modular_reduction(&sum1H, &sum0H).as_arr();
+
+        [hashL[0], hashL[1], hashH[0], hashH[1]]
+    }
+
+    unsafe fn modular_reduction(x: &V2x64U, init: &V2x64U) -> V2x64U {
+        let zero = vdupq_n_u32(0);
+        let sign_bit128 = V2x64U::from(vsetq_lane_u32(0x8000_0000_u32, zero, 3));
+        let top_bits2 = V2x64U::from(vshrq_n_u64(x.0, 62));
+        let shifted1_unmasked = *x + *x;
+        let top_bits1 = V2x64U::from(vshrq_n_u64(x.0, 63));
+        let shifted2 = shifted1_unmasked + shifted1_unmasked;
+        let new_low_bits2 = V2x64U::from(_mm_slli_si128_8(top_bits2.0));
+        let shifted1 = shifted1_unmasked.and_not(&sign_bit128);
+        let new_low_bits1 = V2x64U::from(_mm_slli_si128_8(top_bits1.0));
+        *init ^ shifted2 ^ new_low_bits2 ^ shifted1 ^ new_low_bits1
+    }
+
+    unsafe fn load_multiple_of_four(bytes: &[u8], size: u64) -> V2x64U {
+        let mut data = bytes;
+        let mut mask4 = V2x64U::new(0, 0xFFFF_FFFF);
+        let mut ret = if size & 8 != 0 {
+            mask4 = V2x64U::from(_mm_slli_si128_8(mask4.0));
+            data = &bytes[8..];
+            let lo = u64::from_le_bytes(take::<8>(bytes));
+            V2x64U::new(0, lo)
+        } else {
+            V2x64U::new(0, 0)
+        };
+
+        if size & 4 != 0 {
+            let last4 = u32::from_le_bytes([data[0], data[1], data[2], data[3]]);
+            let broadcast = V2x64U::from(vdupq_n_u32(last4));
+            ret |= broadcast & mask4;
+        }
+
+        ret
+    }
+
+    unsafe fn remainder(bytes: &[u8]) -> (V2x64U, V2x64U) {
+        let size_mod32 = bytes.len();
+        let size_mod4 = size_mod32 & 3;
+        if size_mod32 & 16 != 0 {
+            let packetL = V2x64U::from(vld1q_u8(bytes.as_ptr()));
+            let packett = NeonHash::load_multiple_of_four(&bytes[16..], size_mod32 as u64);
+            let remainder = &bytes[(size_mod32 & !3) + size_mod4 - 4..];
+            let last4 =
+                u32::from_le_bytes([remainder[0], remainder[1], remainder[2], remainder[3]]);
+            let packetH = V2x64U::from(vsetq_lane_u32(last4, vreinterpretq_u32_u64(packett.0), 3));
+            (packetH, packetL)
+        } else {
+            let remainder = &bytes[size_mod32 & !3..];
+            let packetL = NeonHash::load_multiple_of_four(bytes, size_mod32 as u64);
+            let last4 = unordered_load3(remainder);
+            let packetH = V2x64U::new(0, last4);
+            (packetH, packetL)
+        }
+    }
+
+    unsafe fn update_remainder(&mut self) {
+        let size = self.buffer.len() as i32;
+        let vsize_mod32 = V2x64U::from(vdupq_n_s32(size));
+        self.v0L += vsize_mod32;
+        self.v0H += vsize_mod32;
+        self.rotate_32_by(size);
+        let (packetH, packetL) = NeonHash::remainder(self.buffer.as_slice());
+        self.update(packetH, packetL);
+    }
+
+    unsafe fn rotate_32_by(&mut self, count: i32) {
+        let vL = &mut self.v1L;
+        let vH = &mut self.v1H;
+        let count_left = vdupq_n_s32(count);
+        let count_right = vdupq_n_s32(count + (!32 + 1));
+
+        let shifted_leftL = V2x64U::from(vshlq_u32(vreinterpretq_u32_u64(vL.0), count_left));
+        let shifted_leftH = V2x64U::from(vshlq_u32(vreinterpretq_u32_u64(vH.0), count_left));
+        let shifted_rightL = V2x64U::from(vshlq_u32(vreinterpretq_u32_u64(vL.0), count_right));
+        let shifted_rightH = V2x64U::from(vshlq_u32(vreinterpretq_u32_u64(vH.0), count_right));
+        *vL = shifted_leftL | shifted_rightL;
+        *vH = shifted_leftH | shifted_rightH;
+    }
+
+    #[inline]
+    unsafe fn data_to_lanes(packet: &[u8]) -> (V2x64U, V2x64U) {
+        let ptr = packet.as_ptr();
+        let packetL = V2x64U::from(vld1q_u8(ptr));
+        let packetH = V2x64U::from(vld1q_u8(ptr.offset(16)));
+
+        (packetH, packetL)
+    }
+
+    unsafe fn append(&mut self, data: &[u8]) {
+        match self.buffer.fill(data) {
+            Filled::Consumed => {}
+            Filled::Full(new_data) => {
+                let (packetH, packetL) = NeonHash::data_to_lanes(self.buffer.as_slice());
+                self.update(packetH, packetL);
+
+                let mut chunks = new_data.chunks_exact(PACKET_SIZE);
+                for chunk in chunks.by_ref() {
+                    let (packetH, packetL) = NeonHash::data_to_lanes(chunk);
+                    self.update(packetH, packetL);
+                }
+
+                self.buffer.set_to(chunks.remainder());
+            }
+        }
+    }
+}
+
+#[inline]
+fn take<const N: usize>(data: &[u8]) -> [u8; N] {
+    debug_assert!(data.len() >= N);
+    unsafe { *(data.as_ptr() as *const [u8; N]) }
+}
+
+unsafe fn _mm_slli_si128_8(a: uint64x2_t) -> uint64x2_t {
+    // aka _mm_bslli_si128_8
+    let tmp = vreinterpretq_u8_u64(a);
+    let rotated = vextq_u8(vdupq_n_u8(0), tmp, 8);
+    vreinterpretq_u64_u8(rotated)
+}
+
+#[derive(Clone, Copy)]
+pub struct V2x64U(pub uint64x2_t);
+
+impl Default for V2x64U {
+    fn default() -> Self {
+        unsafe { V2x64U::zeroed() }
+    }
+}
+
+impl core::fmt::Debug for V2x64U {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "V2x64U: {:?}", unsafe { self.as_arr() })
+    }
+}
+
+impl V2x64U {
+    unsafe fn zeroed() -> Self {
+        V2x64U(vdupq_n_u64(0))
+    }
+
+    pub unsafe fn new(hi: u64, low: u64) -> Self {
+        V2x64U(vld1q_u64([low, hi].as_ptr()))
+    }
+
+    pub unsafe fn as_arr(&self) -> [u64; 2] {
+        let mut arr: [u64; 2] = [0, 0];
+        vst1q_u64(arr.as_mut_ptr(), self.0);
+        arr
+    }
+
+    pub unsafe fn rotate_by_32(&self) -> Self {
+        let tmp = vreinterpretq_u32_u64(self.0);
+        let rotated = vrev64q_u32(tmp);
+        V2x64U(vreinterpretq_u64_u32(rotated))
+    }
+
+    pub unsafe fn and_not(&self, neg_mask: &V2x64U) -> Self {
+        V2x64U::from(vbicq_u64(self.0, neg_mask.0))
+    }
+
+    unsafe fn add_assign(&mut self, other: Self) {
+        self.0 = vaddq_u64(self.0, other.0)
+    }
+
+    unsafe fn sub_assign(&mut self, other: Self) {
+        self.0 = vsubq_u64(self.0, other.0)
+    }
+
+    unsafe fn bitand_assign(&mut self, other: Self) {
+        self.0 = vandq_u64(self.0, other.0)
+    }
+
+    unsafe fn bitor_assign(&mut self, other: Self) {
+        self.0 = vorrq_u64(self.0, other.0)
+    }
+
+    unsafe fn bitxor_assign(&mut self, other: Self) {
+        self.0 = veorq_u64(self.0, other.0)
+    }
+}
+
+impl From<uint64x2_t> for V2x64U {
+    fn from(v: uint64x2_t) -> Self {
+        V2x64U(v)
+    }
+}
+
+impl From<uint32x4_t> for V2x64U {
+    fn from(v: uint32x4_t) -> Self {
+        V2x64U(unsafe { vreinterpretq_u64_u32(v) })
+    }
+}
+
+impl From<int32x4_t> for V2x64U {
+    fn from(v: int32x4_t) -> Self {
+        V2x64U(unsafe { vreinterpretq_u64_s32(v) })
+    }
+}
+
+impl From<uint16x8_t> for V2x64U {
+    fn from(v: uint16x8_t) -> Self {
+        V2x64U(unsafe { vreinterpretq_u64_u16(v) })
+    }
+}
+
+impl From<uint8x16_t> for V2x64U {
+    fn from(v: uint8x16_t) -> Self {
+        V2x64U(unsafe { vreinterpretq_u64_u8(v) })
+    }
+}
+
+impl AddAssign for V2x64U {
+    fn add_assign(&mut self, other: Self) {
+        unsafe { self.add_assign(other) }
+    }
+}
+
+impl SubAssign for V2x64U {
+    fn sub_assign(&mut self, other: Self) {
+        unsafe { self.sub_assign(other) }
+    }
+}
+
+impl BitAndAssign for V2x64U {
+    fn bitand_assign(&mut self, other: Self) {
+        unsafe { self.bitand_assign(other) }
+    }
+}
+
+impl BitAnd for V2x64U {
+    type Output = Self;
+    fn bitand(self, other: Self) -> Self {
+        let mut new = V2x64U(self.0);
+        new &= other;
+        new
+    }
+}
+
+impl BitOrAssign for V2x64U {
+    fn bitor_assign(&mut self, other: Self) {
+        unsafe { self.bitor_assign(other) }
+    }
+}
+
+impl BitOr for V2x64U {
+    type Output = Self;
+    fn bitor(self, other: Self) -> Self {
+        let mut new = V2x64U(self.0);
+        new |= other;
+        new
+    }
+}
+
+impl BitXorAssign for V2x64U {
+    fn bitxor_assign(&mut self, other: Self) {
+        unsafe { self.bitxor_assign(other) }
+    }
+}
+
+impl Add for V2x64U {
+    type Output = Self;
+
+    fn add(self, other: Self) -> Self {
+        let mut new = V2x64U(self.0);
+        new += other;
+        new
+    }
+}
+
+impl BitXor for V2x64U {
+    type Output = Self;
+
+    fn bitxor(self, other: Self) -> Self {
+        let mut new = V2x64U(self.0);
+        new ^= other;
+        new
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+
+    #[test]
+    fn test_as_arr() {
+        unsafe {
+            let x = V2x64U::new(55, 1);
+            let res = x.as_arr();
+            assert_eq!(res, [1, 55]);
+        }
+    }
+
+    #[test]
+    fn test_rotate_by_32() {
+        unsafe {
+            let x = V2x64U::new(0x0264_432C_CD8A_70E0, 0x0B28_E3EF_EBB3_172D);
+            let y = x.rotate_by_32();
+            let res = y.as_arr();
+            assert_eq!(res, [0xEBB3_172D_0B28_E3EF, 0xCD8A_70E0_0264_432C]);
+        }
+    }
+
+    #[test]
+    fn test_add() {
+        unsafe {
+            let x = V2x64U::new(55, 1);
+            let y = V2x64U::new(0x0264_432C_CD8A_70E0, 0x0B28_E3EF_EBB3_172D);
+            let z = x + y;
+            assert_eq!(z.as_arr(), [0x0B28_E3EF_EBB3_172E, 0x0264_432C_CD8A_7117]);
+        }
+    }
+
+    #[test]
+    fn test_mm_slli_si128_8() {
+        unsafe {
+            let x = V2x64U::new(0, 0xFFFF_FFFF);
+            let y = V2x64U::from(_mm_slli_si128_8(x.0));
+            assert_eq!(y.as_arr(), [0, 0xFFFF_FFFF]);
+        }
+    }
+}

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -1,5 +1,6 @@
 #[cfg(any(
     target_arch = "x86_64",
+    target_arch = "aarch64",
     all(target_family = "wasm", target_feature = "simd128")
 ))]
 pub fn unordered_load3(from: &[u8]) -> u64 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -173,6 +173,8 @@ pub use crate::key::Key;
 pub use crate::portable::PortableHash;
 pub use crate::traits::HighwayHash;
 
+#[cfg(target_arch = "aarch64")]
+mod aarch64;
 #[cfg(target_arch = "x86_64")]
 mod avx;
 #[cfg(target_arch = "x86_64")]
@@ -184,6 +186,8 @@ mod v4x64u;
 #[cfg(all(target_family = "wasm", target_feature = "simd128"))]
 mod wasm;
 
+#[cfg(target_arch = "aarch64")]
+pub use crate::aarch64::NeonHash;
 #[cfg(target_arch = "x86_64")]
 pub use crate::avx::AvxHash;
 #[cfg(target_arch = "x86_64")]

--- a/tests/aarch64.rs
+++ b/tests/aarch64.rs
@@ -1,0 +1,45 @@
+#![cfg(target_arch = "aarch64")]
+use highway::{HighwayHash, Key, NeonHash, PortableHash};
+
+#[test]
+fn hash_zeroes() {
+    let key = Key([0, 0, 0, 0]);
+    let hash = unsafe { NeonHash::force_new(key) }.hash64(&[]);
+    assert_eq!(0x7035_DA75_B9D5_4469, hash);
+}
+
+#[test]
+fn hash_simple() {
+    let key = Key([1, 2, 3, 4]);
+    let b: Vec<u8> = (0..33).map(|x| 128 + x as u8).collect();
+    let hash = unsafe { NeonHash::force_new(key) }.hash64(&b[..]);
+    assert_eq!(0x53c5_16cc_e478_cad7, hash);
+}
+
+#[test]
+fn neon_eq_portable() {
+    let data: Vec<u8> = (0..100).map(|x| x as u8).collect();
+    let key = Key([
+        0x0706_0504_0302_0100,
+        0x0F0E_0D0C_0B0A_0908,
+        0x1716_1514_1312_1110,
+        0x1F1E_1D1C_1B1A_1918,
+    ]);
+
+    for i in 0..data.len() {
+        assert_eq!(
+            unsafe { NeonHash::force_new(key) }.hash64(&data[..i]),
+            PortableHash::new(key).hash64(&data[..i])
+        );
+
+        assert_eq!(
+            unsafe { NeonHash::force_new(key) }.hash128(&data[..i]),
+            PortableHash::new(key).hash128(&data[..i])
+        );
+
+        assert_eq!(
+            unsafe { NeonHash::force_new(key) }.hash256(&data[..i]),
+            PortableHash::new(key).hash256(&data[..i])
+        );
+    }
+}


### PR DESCRIPTION
Based on discussions here: https://github.com/nickbabcock/highway-rs/pull/51#discussion_r815247129

The following aren't stable:
- std::is_aarch64_feature_detected
- aarch64 target features

We're not really able to detect at runtime or compile time if neon
support is available

The good news is that it seems reasonable to assume the aarch64
environment is neon capable. If a use case is found where neon is not
available, we can patch that in later.

Benchmarks on a t4g.small

| payload (bytes) by MiB/s | 0.7 | 0.8  | improvement |
|--------------------------|-----|------|-------------|
| 1                        | 4.4 | 12.2 | 2.8x        |
| 65536                    | 930 | 3897 | 4.2x        |

Closes #29 