### PR TITLE
Complete rename HighwayBuilder -> HighwayHasher

### DIFF
--- a/benches/bench_hashes.rs
+++ b/benches/bench_hashes.rs
@@ -1,7 +1,7 @@
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 #[cfg(target_arch = "x86_64")]
 use highway::{AvxHash, SseHash};
-use highway::{HighwayBuilder, HighwayHash, Key, PortableHash};
+use highway::{HighwayHash, HighwayHasher, Key, PortableHash};
 
 fn builder(c: &mut Criterion) {
     let mut group = c.benchmark_group("highway-builder");
@@ -11,7 +11,7 @@ fn builder(c: &mut Criterion) {
         group.bench_with_input(BenchmarkId::from_parameter(size), size, |b, size| {
             let data = vec![0u8; *size];
             let key = Key([0, 0, 0, 0]);
-            b.iter(|| HighwayBuilder::new(key).hash64(&data));
+            b.iter(|| HighwayHasher::new(key).hash64(&data));
         });
     }
 

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -1,9 +1,6 @@
-use crate::builder::HighwayBuilder;
+use crate::builder::HighwayHasher;
 use crate::key::Key;
 use core::hash::BuildHasher;
-
-/// HighwayHash implementation that selects best hash implementation at runtime.
-pub type HighwayHasher = HighwayBuilder;
 
 /// Constructs a hasher used in rust collections
 #[derive(Debug, Default)]
@@ -22,6 +19,6 @@ impl BuildHasher for HighwayBuildHasher {
     type Hasher = HighwayHasher;
 
     fn build_hasher(&self) -> Self::Hasher {
-        HighwayBuilder::new(self.key)
+        HighwayHasher::new(self.key)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -167,8 +167,8 @@ mod key;
 mod portable;
 mod traits;
 
-pub use crate::builder::HighwayBuilder;
-pub use crate::hash::{HighwayBuildHasher, HighwayHasher};
+pub use crate::builder::HighwayHasher;
+pub use crate::hash::HighwayBuildHasher;
 pub use crate::key::Key;
 pub use crate::portable::PortableHash;
 pub use crate::traits::HighwayHash;

--- a/tests/hash.rs
+++ b/tests/hash.rs
@@ -598,7 +598,7 @@ fn avx_survive_crash() {
 
 #[test]
 fn builder_hash_eq_portable() {
-    use highway::HighwayBuilder;
+    use highway::HighwayHasher;
 
     let data: Vec<u8> = (0..100).map(|x| x as u8).collect();
     let key = Key([
@@ -612,17 +612,17 @@ fn builder_hash_eq_portable() {
         println!("{}", i);
         assert_eq!(
             PortableHash::new(key).hash64(&data[..i]),
-            HighwayBuilder::new(key).hash64(&data[..i])
+            HighwayHasher::new(key).hash64(&data[..i])
         );
 
         assert_eq!(
             PortableHash::new(key).hash128(&data[..i]),
-            HighwayBuilder::new(key).hash128(&data[..i])
+            HighwayHasher::new(key).hash128(&data[..i])
         );
 
         assert_eq!(
             PortableHash::new(key).hash256(&data[..i]),
-            HighwayBuilder::new(key).hash256(&data[..i])
+            HighwayHasher::new(key).hash256(&data[..i])
         );
     }
 }

--- a/tests/properties.rs
+++ b/tests/properties.rs
@@ -2,7 +2,7 @@
 extern crate quickcheck_macros;
 
 mod quick_tests {
-    use highway::{HighwayBuilder, HighwayHash, Key, PortableHash};
+    use highway::{HighwayHash, HighwayHasher, Key, PortableHash};
 
     #[quickcheck]
     fn portable64_eq(k1: u64, k2: u64, k3: u64, k4: u64, data: Vec<u8>) -> bool {
@@ -31,24 +31,24 @@ mod quick_tests {
     #[quickcheck]
     fn builder64_eq(k1: u64, k2: u64, k3: u64, k4: u64, data: Vec<u8>) -> bool {
         let key = Key([k1, k2, k3, k4]);
-        let hash1 = HighwayBuilder::new(key).hash64(data.as_slice());
-        let hash2 = HighwayBuilder::new(key).hash64(data.as_slice());
+        let hash1 = HighwayHasher::new(key).hash64(data.as_slice());
+        let hash2 = HighwayHasher::new(key).hash64(data.as_slice());
         hash1 == hash2
     }
 
     #[quickcheck]
     fn builder128_eq(k1: u64, k2: u64, k3: u64, k4: u64, data: Vec<u8>) -> bool {
         let key = Key([k1, k2, k3, k4]);
-        let hash1 = HighwayBuilder::new(key).hash128(data.as_slice());
-        let hash2 = HighwayBuilder::new(key).hash128(data.as_slice());
+        let hash1 = HighwayHasher::new(key).hash128(data.as_slice());
+        let hash2 = HighwayHasher::new(key).hash128(data.as_slice());
         hash1 == hash2
     }
 
     #[quickcheck]
     fn builder256_eq(k1: u64, k2: u64, k3: u64, k4: u64, data: Vec<u8>) -> bool {
         let key = Key([k1, k2, k3, k4]);
-        let hash1 = HighwayBuilder::new(key).hash256(data.as_slice());
-        let hash2 = HighwayBuilder::new(key).hash256(data.as_slice());
+        let hash1 = HighwayHasher::new(key).hash256(data.as_slice());
+        let hash2 = HighwayHasher::new(key).hash256(data.as_slice());
         hash1 == hash2
     }
 
@@ -56,7 +56,7 @@ mod quick_tests {
     fn all64_eq(k1: u64, k2: u64, k3: u64, k4: u64, data: Vec<u8>) -> bool {
         let key = Key([k1, k2, k3, k4]);
         let hash1 = PortableHash::new(key).hash64(data.as_slice());
-        let hash2 = HighwayBuilder::new(key).hash64(data.as_slice());
+        let hash2 = HighwayHasher::new(key).hash64(data.as_slice());
 
         #[cfg(target_arch = "x86_64")]
         {
@@ -82,7 +82,7 @@ mod quick_tests {
     fn all128_eq(k1: u64, k2: u64, k3: u64, k4: u64, data: Vec<u8>) -> bool {
         let key = Key([k1, k2, k3, k4]);
         let hash1 = PortableHash::new(key).hash128(data.as_slice());
-        let hash2 = HighwayBuilder::new(key).hash128(data.as_slice());
+        let hash2 = HighwayHasher::new(key).hash128(data.as_slice());
 
         #[cfg(target_arch = "x86_64")]
         {
@@ -108,7 +108,7 @@ mod quick_tests {
     fn all256_eq(k1: u64, k2: u64, k3: u64, k4: u64, data: Vec<u8>) -> bool {
         let key = Key([k1, k2, k3, k4]);
         let hash1 = PortableHash::new(key).hash256(data.as_slice());
-        let hash2 = HighwayBuilder::new(key).hash256(data.as_slice());
+        let hash2 = HighwayHasher::new(key).hash256(data.as_slice());
 
         #[cfg(target_arch = "x86_64")]
         {


### PR DESCRIPTION
Back in v0.6.0, the `HighwayHasher` alias was introduced for
`HighwayBuilder`. I was never happy with the `HighwayBuilder` moniker as
it doesn't feel right for the main entrypoint of an API to use `Builder`
when a better name exists.

Thus the `HighwayHasher` alias was born as a way to test the waters
without needless backwars incompatibilities.

And now after a year and a half, it seems right to fully commit to the
alias