### PR TITLE
Eliminate panics

### DIFF
--- a/src/internal.rs
+++ b/src/internal.rs
@@ -40,21 +40,63 @@ impl HashPacket {
 
     #[inline]
     pub fn as_slice(&self) -> &[u8] {
-        &self.buf[..self.buf_index]
+        if self.buf_index > self.buf.len() {
+            debug_assert!(false, "buf index can't exceed buf length");
+            return &self.buf;
+        } else {
+            &self.buf[..self.buf_index]
+        }
+    }
+
+    #[inline]
+    pub fn inner(&self) -> &[u8; PACKET_SIZE] {
+        &self.buf
     }
 
     #[inline]
     pub fn fill<'a>(&mut self, data: &'a [u8]) -> Option<&'a [u8]> {
-        if data.len() < PACKET_SIZE - self.buf_index {
-            let new_ind = self.buf_index + data.len();
-            self.buf[self.buf_index..new_ind].copy_from_slice(data);
-            self.buf_index = new_ind;
-            None
-        } else {
+        // This function is a lot longer than it should be as it's the only way
+        // I could get 100% safe code that the compiler knew wouldn't panic.
+
+        let filled_len = PACKET_SIZE - self.buf_index;
+        if data.len() >= filled_len {
             let (head, tail) = data.split_at(PACKET_SIZE - self.buf_index);
-            self.buf[self.buf_index..].copy_from_slice(head);
+
+            let buf_tail = match self.buf.get_mut(self.buf_index..) {
+                Some(x) => x,
+                None => {
+                    debug_assert!(false, "buf index should never exceed buffer");
+                    return None;
+                }
+            };
+
             self.buf_index = PACKET_SIZE;
-            Some(tail)
+            if buf_tail.len() == head.len() {
+                buf_tail.copy_from_slice(head);
+                Some(tail)
+            } else {
+                debug_assert!(false, "expected tail of buffer to equal head of data");
+                None
+            }
+        } else {
+            let new_ind = self.buf_index + data.len();
+
+            let buf_tail = match self.buf.get_mut(self.buf_index..new_ind) {
+                Some(x) => x,
+                None => {
+                    debug_assert!(false, "buf index should never exceed buffer");
+                    return None;
+                }
+            };
+
+            self.buf_index = new_ind;
+            if buf_tail.len() == data.len() {
+                buf_tail.copy_from_slice(data);
+                None
+            } else {
+                debug_assert!(false, "expected tail of buffer to equal head of data");
+                None
+            }
         }
     }
 

--- a/src/x86/avx.rs
+++ b/src/x86/avx.rs
@@ -254,7 +254,7 @@ impl AvxHash {
     #[target_feature(enable = "avx2")]
     unsafe fn append(&mut self, data: &[u8]) {
         if let Some(tail) = self.buffer.fill(data) {
-            self.update(Self::data_to_lanes(self.buffer.as_slice()));
+            self.update(Self::data_to_lanes(self.buffer.inner()));
             let mut chunks = tail.chunks_exact(PACKET_SIZE);
             for chunk in chunks.by_ref() {
                 self.update(Self::data_to_lanes(chunk));

--- a/src/x86/sse.rs
+++ b/src/x86/sse.rs
@@ -204,7 +204,7 @@ impl SseHash {
     unsafe fn load_multiple_of_four(bytes: &[u8], size: u64) -> V2x64U {
         let mut data = bytes;
         let mut mask4 = V2x64U::from(_mm_cvtsi64_si128(0xFFFF_FFFF));
-        let mut ret = if size & 8 != 0 {
+        let mut ret = if bytes.len() >= 8 {
             mask4 = V2x64U::from(_mm_slli_si128(mask4.0, 8));
             data = &bytes[8..];
             V2x64U::from(_mm_loadl_epi64(bytes.as_ptr().cast::<__m128i>()))
@@ -281,7 +281,7 @@ impl SseHash {
     #[target_feature(enable = "sse4.1")]
     unsafe fn append(&mut self, data: &[u8]) {
         if let Some(tail) = self.buffer.fill(data) {
-            self.update(Self::data_to_lanes(self.buffer.as_slice()));
+            self.update(Self::data_to_lanes(self.buffer.inner()));
             let mut chunks = tail.chunks_exact(PACKET_SIZE);
             for chunk in chunks.by_ref() {
                 self.update(Self::data_to_lanes(chunk));


### PR DESCRIPTION
Looking at the release assembly, I found instances where the compiler couldn't tell that the code couldn't panic, so I massaged it so the compiler could better infer.

This should mean that the hashers (or at least the portable hasher) is panic-less.

Throughput improved by about a few percentage points. Nothing exciting, and I was able to verify that the amount of assembly decreased.