### PR TITLE
Update to edition 2021

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ categories = ["algorithms", "cryptography", "no-std"]
 description = "Native Rust port of Google's HighwayHash, which makes use of SIMD instructions for a fast and strong hash function"
 keywords = ["HighwayHash", "hasher", "hash", "simd", "avx"]
 include = ["src/**/*.rs", "benches"]
-edition = "2018"
+edition = "2021"
 
 [features]
 default = ["std"]


### PR DESCRIPTION
This should be a backwards compatible change as the MSRV required for edition 2021 is 1.56 and the currently advertised MSRV here is 1.59.

The edition bump to default to the new cargo resolver to fix the criterion compilation errors when testing for wasm.