### PR TITLE
Optimize HighwayHasher builder for small inputs

### DIFF
--- a/src/aarch64.rs
+++ b/src/aarch64.rs
@@ -108,7 +108,7 @@ impl NeonHash {
         self.update((low, high));
     }
 
-    unsafe fn finalize64(&mut self) -> u64 {
+    pub(crate) unsafe fn finalize64(&mut self) -> u64 {
         if !self.buffer.is_empty() {
             self.update_remainder();
         }
@@ -123,7 +123,7 @@ impl NeonHash {
         hash.as_arr()[0]
     }
 
-    unsafe fn finalize128(&mut self) -> [u64; 2] {
+    pub(crate) unsafe fn finalize128(&mut self) -> [u64; 2] {
         if !self.buffer.is_empty() {
             self.update_remainder();
         }
@@ -138,7 +138,7 @@ impl NeonHash {
         hash.as_arr()
     }
 
-    unsafe fn finalize256(&mut self) -> [u64; 4] {
+    pub(crate) unsafe fn finalize256(&mut self) -> [u64; 4] {
         if !self.buffer.is_empty() {
             self.update_remainder();
         }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,6 +1,6 @@
 use crate::key::Key;
 use crate::traits::HighwayHash;
-use core::default::Default;
+use core::{default::Default, fmt::Debug, mem::ManuallyDrop};
 
 #[cfg(target_arch = "aarch64")]
 use crate::aarch64::NeonHash;
@@ -14,98 +14,105 @@ use crate::wasm::WasmHash;
 #[cfg(target_arch = "x86_64")]
 use crate::{AvxHash, SseHash};
 
-#[derive(Debug, Clone)]
-enum HighwayChoices {
+/// This union is purely for performance. Originally it was an enum, but Rust /
+/// LLVM had a hard time optimizing it and would include memcpy's that would
+/// dominate profiles.
+union HighwayChoices {
     #[cfg(not(any(
         all(target_family = "wasm", target_feature = "simd128"),
         target_arch = "aarch64"
     )))]
-    Portable(PortableHash),
+    portable: ManuallyDrop<PortableHash>,
     #[cfg(target_arch = "x86_64")]
-    Sse(SseHash),
+    avx: ManuallyDrop<AvxHash>,
     #[cfg(target_arch = "x86_64")]
-    Avx(AvxHash),
+    sse: ManuallyDrop<SseHash>,
     #[cfg(target_arch = "aarch64")]
-    Neon(NeonHash),
+    neon: ManuallyDrop<NeonHash>,
     #[cfg(all(target_family = "wasm", target_feature = "simd128"))]
-    Wasm(WasmHash),
+    wasm: ManuallyDrop<WasmHash>,
 }
 
 /// HighwayHash implementation that selects best hash implementation at runtime.
-#[derive(Debug, Clone)]
-pub struct HighwayHasher(HighwayChoices);
+pub struct HighwayHasher {
+    tag: u8,
+    inner: HighwayChoices,
+}
+
+impl Debug for HighwayHasher {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("HighwayHasher")
+            .field("tag", &self.tag)
+            .finish()
+    }
+}
+
+impl Clone for HighwayHasher {
+    fn clone(&self) -> Self {
+        let tag = self.tag;
+        match tag {
+            #[cfg(not(any(
+                all(target_family = "wasm", target_feature = "simd128"),
+                target_arch = "aarch64"
+            )))]
+            0 => HighwayHasher {
+                tag,
+                inner: HighwayChoices {
+                    portable: unsafe { self.inner.portable.clone() },
+                },
+            },
+            #[cfg(target_arch = "x86_64")]
+            1 => HighwayHasher {
+                tag,
+                inner: HighwayChoices {
+                    avx: unsafe { self.inner.avx.clone() },
+                },
+            },
+            #[cfg(target_arch = "x86_64")]
+            2 => HighwayHasher {
+                tag,
+                inner: HighwayChoices {
+                    sse: unsafe { self.inner.sse.clone() },
+                },
+            },
+            #[cfg(target_arch = "aarch64")]
+            3 => HighwayHasher {
+                tag,
+                inner: HighwayChoices {
+                    neon: unsafe { self.inner.neon.clone() },
+                },
+            },
+            #[cfg(all(target_family = "wasm", target_feature = "simd128"))]
+            4 => HighwayHasher {
+                tag,
+                inner: HighwayChoices {
+                    wasm: unsafe { self.inner.wasm.clone() },
+                },
+            },
+            _ => unsafe { core::hint::unreachable_unchecked() },
+        }
+    }
+}
 
 impl HighwayHash for HighwayHasher {
+    #[inline]
     fn append(&mut self, data: &[u8]) {
-        match &mut self.0 {
-            #[cfg(not(any(
-                all(target_family = "wasm", target_feature = "simd128"),
-                target_arch = "aarch64"
-            )))]
-            HighwayChoices::Portable(x) => x.append(data),
-            #[cfg(target_arch = "x86_64")]
-            HighwayChoices::Avx(x) => x.append(data),
-            #[cfg(target_arch = "x86_64")]
-            HighwayChoices::Sse(x) => x.append(data),
-            #[cfg(target_arch = "aarch64")]
-            HighwayChoices::Neon(x) => x.append(data),
-            #[cfg(all(target_family = "wasm", target_feature = "simd128"))]
-            HighwayChoices::Wasm(x) => x.append(data),
-        }
+        self.append(data)
     }
 
-    fn finalize64(self) -> u64 {
-        match self.0 {
-            #[cfg(not(any(
-                all(target_family = "wasm", target_feature = "simd128"),
-                target_arch = "aarch64"
-            )))]
-            HighwayChoices::Portable(x) => x.finalize64(),
-            #[cfg(target_arch = "x86_64")]
-            HighwayChoices::Avx(x) => x.finalize64(),
-            #[cfg(target_arch = "x86_64")]
-            HighwayChoices::Sse(x) => x.finalize64(),
-            #[cfg(target_arch = "aarch64")]
-            HighwayChoices::Neon(x) => x.finalize64(),
-            #[cfg(all(target_family = "wasm", target_feature = "simd128"))]
-            HighwayChoices::Wasm(x) => x.finalize64(),
-        }
+    #[inline]
+    fn finalize64(mut self) -> u64 {
+        Self::finalize64(&mut self)
     }
 
-    fn finalize128(self) -> [u64; 2] {
-        match self.0 {
-            #[cfg(not(any(
-                all(target_family = "wasm", target_feature = "simd128"),
-                target_arch = "aarch64"
-            )))]
-            HighwayChoices::Portable(x) => x.finalize128(),
-            #[cfg(target_arch = "x86_64")]
-            HighwayChoices::Avx(x) => x.finalize128(),
-            #[cfg(target_arch = "x86_64")]
-            HighwayChoices::Sse(x) => x.finalize128(),
-            #[cfg(target_arch = "aarch64")]
-            HighwayChoices::Neon(x) => x.finalize128(),
-            #[cfg(all(target_family = "wasm", target_feature = "simd128"))]
-            HighwayChoices::Wasm(x) => x.finalize128(),
-        }
+    #[inline]
+    fn finalize128(mut self) -> [u64; 2] {
+        Self::finalize128(&mut self)
     }
 
-    fn finalize256(self) -> [u64; 4] {
-        match self.0 {
-            #[cfg(not(any(
-                all(target_family = "wasm", target_feature = "simd128"),
-                target_arch = "aarch64"
-            )))]
-            HighwayChoices::Portable(x) => x.finalize256(),
-            #[cfg(target_arch = "x86_64")]
-            HighwayChoices::Avx(x) => x.finalize256(),
-            #[cfg(target_arch = "x86_64")]
-            HighwayChoices::Sse(x) => x.finalize256(),
-            #[cfg(target_arch = "aarch64")]
-            HighwayChoices::Neon(x) => x.finalize256(),
-            #[cfg(all(target_family = "wasm", target_feature = "simd128"))]
-            HighwayChoices::Wasm(x) => x.finalize256(),
-        }
+    #[inline]
+    fn finalize256(mut self) -> [u64; 4] {
+        Self::finalize256(&mut self)
     }
 }
 
@@ -116,18 +123,36 @@ impl HighwayHasher {
         #[cfg(target_arch = "x86_64")]
         {
             if cfg!(target_feature = "avx2") {
-                let h = unsafe { AvxHash::force_new(key) };
-                return HighwayHasher(HighwayChoices::Avx(h));
+                let avx = ManuallyDrop::new(unsafe { AvxHash::force_new(key) });
+                return HighwayHasher {
+                    tag: 1,
+                    inner: HighwayChoices { avx },
+                };
             } else if cfg!(target_feature = "sse4.1") {
-                let h = unsafe { SseHash::force_new(key) };
-                return HighwayHasher(HighwayChoices::Sse(h));
+                let sse = ManuallyDrop::new(unsafe { SseHash::force_new(key) });
+                return HighwayHasher {
+                    tag: 2,
+                    inner: HighwayChoices { sse },
+                };
             } else {
-                if let Some(h) = AvxHash::new(key) {
-                    return HighwayHasher(HighwayChoices::Avx(h));
+                // Ideally we'd use `AvxHash::new` here, but it triggers a memcpy, so we
+                // duplicate the same logic to know if hasher can be enabled.
+                #[cfg(feature = "std")]
+                if is_x86_feature_detected!("avx2") {
+                    let avx = ManuallyDrop::new(unsafe { AvxHash::force_new(key) });
+                    return HighwayHasher {
+                        tag: 1,
+                        inner: HighwayChoices { avx },
+                    };
                 }
 
-                if let Some(h) = SseHash::new(key) {
-                    return HighwayHasher(HighwayChoices::Sse(h));
+                #[cfg(feature = "std")]
+                if is_x86_feature_detected!("sse4.1") {
+                    let sse = ManuallyDrop::new(unsafe { SseHash::force_new(key) });
+                    return HighwayHasher {
+                        tag: 2,
+                        inner: HighwayChoices { sse },
+                    };
                 }
             }
         }
@@ -147,13 +172,20 @@ impl HighwayHasher {
             // The good news is that it seems reasonable to assume the
             // aarch64 environment is neon capable. If a use case is found
             // where neon is not available, we can patch that in later.
-            let h = unsafe { NeonHash::force_new(key) };
-            HighwayHasher(HighwayChoices::Neon(h))
+            let neon = ManuallyDrop::new(unsafe { NeonHash::force_new(key) });
+            HighwayHasher {
+                tag: 3,
+                inner: HighwayChoices { neon },
+            }
         }
 
         #[cfg(all(target_family = "wasm", target_feature = "simd128"))]
         {
-            HighwayHasher(HighwayChoices::Wasm(WasmHash::new(key)))
+            let wasm = ManuallyDrop::new(WasmHash::new(key));
+            HighwayHasher {
+                tag: 4,
+                inner: HighwayChoices { wasm },
+            }
         }
 
         #[cfg(not(any(
@@ -161,7 +193,87 @@ impl HighwayHasher {
             target_arch = "aarch64"
         )))]
         {
-            HighwayHasher(HighwayChoices::Portable(PortableHash::new(key)))
+            let portable = ManuallyDrop::new(PortableHash::new(key));
+            HighwayHasher {
+                tag: 0,
+                inner: HighwayChoices { portable },
+            }
+        }
+    }
+
+    fn append(&mut self, data: &[u8]) {
+        match self.tag {
+            #[cfg(not(any(
+                all(target_family = "wasm", target_feature = "simd128"),
+                target_arch = "aarch64"
+            )))]
+            0 => unsafe { &mut self.inner.portable }.append(data),
+            #[cfg(target_arch = "x86_64")]
+            1 => unsafe { &mut self.inner.avx }.append(data),
+            #[cfg(target_arch = "x86_64")]
+            2 => unsafe { &mut self.inner.sse }.append(data),
+            #[cfg(target_arch = "aarch64")]
+            3 => unsafe { &mut self.inner.neon }.append(data),
+            #[cfg(all(target_family = "wasm", target_feature = "simd128"))]
+            4 => unsafe { &mut self.inner.wasm }.append(data),
+            _ => unsafe { core::hint::unreachable_unchecked() },
+        }
+    }
+
+    fn finalize64(&mut self) -> u64 {
+        match self.tag {
+            #[cfg(not(any(
+                all(target_family = "wasm", target_feature = "simd128"),
+                target_arch = "aarch64"
+            )))]
+            0 => unsafe { PortableHash::finalize64(&mut self.inner.portable) },
+            #[cfg(target_arch = "x86_64")]
+            1 => unsafe { AvxHash::finalize64(&mut self.inner.avx) },
+            #[cfg(target_arch = "x86_64")]
+            2 => unsafe { SseHash::finalize64(&mut self.inner.sse) },
+            #[cfg(target_arch = "aarch64")]
+            3 => unsafe { NeonHash::finalize64(&mut self.inner.neon) },
+            #[cfg(all(target_family = "wasm", target_feature = "simd128"))]
+            4 => unsafe { WasmHash::finalize64(&mut self.inner.wasm) },
+            _ => unsafe { core::hint::unreachable_unchecked() },
+        }
+    }
+
+    fn finalize128(&mut self) -> [u64; 2] {
+        match self.tag {
+            #[cfg(not(any(
+                all(target_family = "wasm", target_feature = "simd128"),
+                target_arch = "aarch64"
+            )))]
+            0 => unsafe { PortableHash::finalize128(&mut self.inner.portable) },
+            #[cfg(target_arch = "x86_64")]
+            1 => unsafe { AvxHash::finalize128(&mut self.inner.avx) },
+            #[cfg(target_arch = "x86_64")]
+            2 => unsafe { SseHash::finalize128(&mut self.inner.sse) },
+            #[cfg(target_arch = "aarch64")]
+            3 => unsafe { NeonHash::finalize128(&mut self.inner.neon) },
+            #[cfg(all(target_family = "wasm", target_feature = "simd128"))]
+            4 => unsafe { WasmHash::finalize128(&mut self.inner.wasm) },
+            _ => unsafe { core::hint::unreachable_unchecked() },
+        }
+    }
+
+    fn finalize256(&mut self) -> [u64; 4] {
+        match self.tag {
+            #[cfg(not(any(
+                all(target_family = "wasm", target_feature = "simd128"),
+                target_arch = "aarch64"
+            )))]
+            0 => unsafe { PortableHash::finalize256(&mut self.inner.portable) },
+            #[cfg(target_arch = "x86_64")]
+            1 => unsafe { AvxHash::finalize256(&mut self.inner.avx) },
+            #[cfg(target_arch = "x86_64")]
+            2 => unsafe { SseHash::finalize256(&mut self.inner.sse) },
+            #[cfg(target_arch = "aarch64")]
+            3 => unsafe { NeonHash::finalize256(&mut self.inner.neon) },
+            #[cfg(all(target_family = "wasm", target_feature = "simd128"))]
+            4 => unsafe { WasmHash::finalize256(&mut self.inner.wasm) },
+            _ => unsafe { core::hint::unreachable_unchecked() },
         }
     }
 }

--- a/src/portable.rs
+++ b/src/portable.rs
@@ -70,7 +70,7 @@ impl PortableHash {
         }
     }
 
-    fn finalize64(&mut self) -> u64 {
+    pub(crate) fn finalize64(&mut self) -> u64 {
         if !self.buffer.is_empty() {
             self.update_remainder();
         }
@@ -85,7 +85,7 @@ impl PortableHash {
             .wrapping_add(self.mul1[0])
     }
 
-    fn finalize128(&mut self) -> [u64; 2] {
+    pub(crate) fn finalize128(&mut self) -> [u64; 2] {
         if !self.buffer.is_empty() {
             self.update_remainder();
         }
@@ -107,7 +107,7 @@ impl PortableHash {
         [low, high]
     }
 
-    fn finalize256(&mut self) -> [u64; 4] {
+    pub(crate) fn finalize256(&mut self) -> [u64; 4] {
         if !self.buffer.is_empty() {
             self.update_remainder();
         }

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -97,7 +97,7 @@ impl WasmHash {
         self.update((low, high));
     }
 
-    fn finalize64(&mut self) -> u64 {
+    pub(crate) fn finalize64(&mut self) -> u64 {
         if !self.buffer.is_empty() {
             self.update_remainder();
         }
@@ -113,7 +113,7 @@ impl WasmHash {
         wasm32::u64x2_extract_lane::<1>(hash.0)
     }
 
-    fn finalize128(&mut self) -> [u64; 2] {
+    pub(crate) fn finalize128(&mut self) -> [u64; 2] {
         if !self.buffer.is_empty() {
             self.update_remainder();
         }
@@ -131,7 +131,7 @@ impl WasmHash {
         ]
     }
 
-    fn finalize256(&mut self) -> [u64; 4] {
+    pub(crate) fn finalize256(&mut self) -> [u64; 4] {
         if !self.buffer.is_empty() {
             self.update_remainder();
         }

--- a/src/x86/avx.rs
+++ b/src/x86/avx.rs
@@ -95,7 +95,7 @@ impl AvxHash {
     }
 
     #[target_feature(enable = "avx2")]
-    unsafe fn finalize64(&mut self) -> u64 {
+    pub(crate) unsafe fn finalize64(&mut self) -> u64 {
         if !self.buffer.is_empty() {
             self.update_remainder();
         }
@@ -115,7 +115,7 @@ impl AvxHash {
     }
 
     #[target_feature(enable = "avx2")]
-    unsafe fn finalize128(&mut self) -> [u64; 2] {
+    pub(crate) unsafe fn finalize128(&mut self) -> [u64; 2] {
         if !self.buffer.is_empty() {
             self.update_remainder();
         }
@@ -134,7 +134,7 @@ impl AvxHash {
     }
 
     #[target_feature(enable = "avx2")]
-    unsafe fn finalize256(&mut self) -> [u64; 4] {
+    pub(crate) unsafe fn finalize256(&mut self) -> [u64; 4] {
         if !self.buffer.is_empty() {
             self.update_remainder();
         }

--- a/src/x86/sse.rs
+++ b/src/x86/sse.rs
@@ -126,7 +126,7 @@ impl SseHash {
     }
 
     #[target_feature(enable = "sse4.1")]
-    unsafe fn finalize64(&mut self) -> u64 {
+    pub(crate) unsafe fn finalize64(&mut self) -> u64 {
         if !self.buffer.is_empty() {
             self.update_remainder();
         }
@@ -144,7 +144,7 @@ impl SseHash {
     }
 
     #[target_feature(enable = "sse4.1")]
-    unsafe fn finalize128(&mut self) -> [u64; 2] {
+    pub(crate) unsafe fn finalize128(&mut self) -> [u64; 2] {
         if !self.buffer.is_empty() {
             self.update_remainder();
         }
@@ -162,7 +162,7 @@ impl SseHash {
     }
 
     #[target_feature(enable = "sse4.1")]
-    unsafe fn finalize256(&mut self) -> [u64; 4] {
+    pub(crate) unsafe fn finalize256(&mut self) -> [u64; 4] {
         if !self.buffer.is_empty() {
             self.update_remainder();
         }


### PR DESCRIPTION
Through abandoning enums for unions and duplicating the logic to check if a feature is enabled, throughput of hashing small input has increased, sometimes over 50%!

There is still some overhead on small input, but it's now around 10-15%. Worth to consider one-shot functions? Maybe.

Shoutout to the rust [community for helping](https://users.rust-lang.org/t/stateful-simd-enabled-hashing-routine-foiled-by-memcpy-for-small-input/96090?u=nickbabcock)

Closes #67 