### PR TITLE
docstring backtick fix

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -33,7 +33,7 @@ union HighwayChoices {
     wasm: ManuallyDrop<WasmHash>,
 }
 
-/// HighwayHash implementation that selects best hash implementation at runtime.
+/// `HighwayHash` implementation that selects best hash implementation at runtime.
 pub struct HighwayHasher {
     tag: u8,
     inner: HighwayChoices,

--- a/src/key.rs
+++ b/src/key.rs
@@ -1,6 +1,6 @@
 use core::ops::Index;
 
-/// Key used in HighwayHash that will drastically change the hash outputs.
+/// Key used in `HighwayHash` that will drastically change the hash outputs.
 #[derive(Debug, Default, Clone, Copy)]
 #[repr(align(32))]
 pub struct Key(pub [u64; 4]);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@ portable (output is hardware independent) and strong hash function.
 
 ## Caution
 
-HighwayHash (the algorithm) has not undergone extensive cryptanalysis like SipHash (the default hashing algorithm in Rust), but according to the authors, HighwayHash output bits are uniformly distributed and should withstand differential and rotational attacks. Hence HighwayHash is referred to as a strong hash function, not a cryptographic hash function. I encourage anyone interested to [peruse the paper](https://arxiv.org/abs/1612.06257) to understand the risks.
+`HighwayHash` (the algorithm) has not undergone extensive cryptanalysis like SipHash (the default hashing algorithm in Rust), but according to the authors, `HighwayHash` output bits are uniformly distributed and should withstand differential and rotational attacks. Hence `HighwayHash` is referred to as a strong hash function, not a cryptographic hash function. I encourage anyone interested to [peruse the paper](https://arxiv.org/abs/1612.06257) to understand the risks.
 
 ## Examples
 
@@ -125,12 +125,12 @@ let hash256 = hasher.finalize256(); // HighwayHash API
 
 ## Use Cases
 
-HighwayHash can be used against untrusted user input where weak hashes can't be used due to exploitation, verified cryptographic hashes are too slow, and a strong hash function meets requirements. Some specific scenarios given by the authors of HighwayHash:
+`HighwayHash` can be used against untrusted user input where weak hashes can't be used due to exploitation, verified cryptographic hashes are too slow, and a strong hash function meets requirements. Some specific scenarios given by the authors of HighwayHash:
 
 - Use 64bit hashes to for authenticating short lived messages
 - Use 256bit hashes for checksums. Think file storage (S3) or any longer lived data where there is a need for strong guarantees against collisions.
 
-HighwayHash may not be a good fit if the payloads trend small (< 100 bytes) and speed is up of the utmost importance, as HighwayHash hits its stride at larger payloads.
+`HighwayHash` may not be a good fit if the payloads trend small (< 100 bytes) and speed is up of the utmost importance, as HighwayHash hits its stride at larger payloads.
 
 ## Wasm SIMD
 


### PR DESCRIPTION
I added some backticks to the documentation for clarity. Considering that it's not just a key name but the name of the hash i recognize that the original might have been an intentional choice.