### PR TITLE
Swap big endian CI tests to PowerPC from MIPS

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
         - pinned
         - stable
         - stable-32
-        - stable-mips
+        - big-endian
         - beta
         - nightly
         - macos
@@ -42,10 +42,10 @@ jobs:
           os: ubuntu-latest
           rust: stable
           target: i686-unknown-linux-gnu
-        - build: stable-mips
+        - build: big-endian
           os: ubuntu-latest
           rust: stable
-          target: mips64-unknown-linux-gnuabi64
+          target: powerpc64-unknown-linux-gnu
         - build: beta
           os: ubuntu-latest
           rust: beta


### PR DESCRIPTION
MIPS has been downgraded to tier 3, so we swap it to powerpc so we can accurately test big endian architectures