### PR TITLE
add conditional checking of neon

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -175,10 +175,10 @@ impl HighwayHasher {
             #[cfg(target_feature = "neon")]
             if cfg!(target_feature = "neon") {
                 let neon = ManuallyDrop::new(unsafe { NeonHash::force_new(key) });
-                HighwayHasher {
+                return HighwayHasher {
                     tag: 3,
                     inner: HighwayChoices { neon },
-                }
+                };
             }
             #[cfg(feature = "std")]
             if is_aarch64_feature_detected!("neon") {

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -176,18 +176,18 @@ impl HighwayHasher {
             if cfg!(target_feature = "neon") {
                 if is_aarch64_feature_detected!("neon") {
                     let neon = ManuallyDrop::new(unsafe { NeonHash::force_new(key) });
-                    HighwayHasher {
+                    return HighwayHasher {
                         tag: 3,
                         inner: HighwayChoices { neon },
-                    }
+                    };
                 } else {
                     #[cfg(feature = "std")]
                     if is_aarch64_feature_detected!("neon") {
                         let neon = ManuallyDrop::new(unsafe { NeonHash::force_new(key) });
-                        HighwayHasher {
+                        return HighwayHasher {
                             tag: 3,
                             inner: HighwayChoices { neon },
-                        }
+                        };
                     }
                 }
             }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -180,15 +180,15 @@ impl HighwayHasher {
                         tag: 3,
                         inner: HighwayChoices { neon },
                     };
-                } else {
-                    #[cfg(feature = "std")]
-                    if is_aarch64_feature_detected!("neon") {
-                        let neon = ManuallyDrop::new(unsafe { NeonHash::force_new(key) });
-                        return HighwayHasher {
-                            tag: 3,
-                            inner: HighwayChoices { neon },
-                        };
-                    }
+                }
+            } else {
+                #[cfg(feature = "std")]
+                if is_aarch64_feature_detected!("neon") {
+                    let neon = ManuallyDrop::new(unsafe { NeonHash::force_new(key) });
+                    return HighwayHasher {
+                        tag: 3,
+                        inner: HighwayChoices { neon },
+                    };
                 }
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -173,14 +173,14 @@ pub use crate::key::Key;
 pub use crate::portable::PortableHash;
 pub use crate::traits::HighwayHash;
 
-#[cfg(all(target_arch = "aarch64",target_feature="neon"))]
+#[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
 mod aarch64;
 #[cfg(all(target_family = "wasm", target_feature = "simd128"))]
 mod wasm;
 #[cfg(target_arch = "x86_64")]
 mod x86;
 
-#[cfg(all(target_arch = "aarch64",target_feature="neon"))]
+#[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
 pub use crate::aarch64::NeonHash;
 #[cfg(target_arch = "x86_64")]
 pub use crate::x86::{AvxHash, SseHash};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -173,14 +173,14 @@ pub use crate::key::Key;
 pub use crate::portable::PortableHash;
 pub use crate::traits::HighwayHash;
 
-#[cfg(target_arch = "aarch64")]
+#[cfg(all(target_arch = "aarch64",target_feature="neon"))]
 mod aarch64;
 #[cfg(all(target_family = "wasm", target_feature = "simd128"))]
 mod wasm;
 #[cfg(target_arch = "x86_64")]
 mod x86;
 
-#[cfg(target_arch = "aarch64")]
+#[cfg(all(target_arch = "aarch64",target_feature="neon"))]
 pub use crate::aarch64::NeonHash;
 #[cfg(target_arch = "x86_64")]
 pub use crate::x86::{AvxHash, SseHash};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -173,14 +173,14 @@ pub use crate::key::Key;
 pub use crate::portable::PortableHash;
 pub use crate::traits::HighwayHash;
 
-#[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
+#[cfg(target_arch = "aarch64")]
 mod aarch64;
 #[cfg(all(target_family = "wasm", target_feature = "simd128"))]
 mod wasm;
 #[cfg(target_arch = "x86_64")]
 mod x86;
 
-#[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
+#[cfg(target_arch = "aarch64")]
 pub use crate::aarch64::NeonHash;
 #[cfg(target_arch = "x86_64")]
 pub use crate::x86::{AvxHash, SseHash};


### PR DESCRIPTION
Target attribute [aarch64](https://doc.rust-lang.org/reference/attributes/codegen.html#aarch64) 
and
[std::arch::is_aarch64_feature_detected](https://doc.rust-lang.org/stable/std/arch/macro.is_aarch64_feature_detected.html)
seem to be stabilised now 
https://github.com/rust-lang/rust/issues/86941
https://github.com/rust-lang/rust/issues/90620

Would this be a good idea now?
If so, how could I test this?