### PR TITLE
Add deny unsafe lint

### DIFF
--- a/src/aarch64.rs
+++ b/src/aarch64.rs
@@ -1,3 +1,4 @@
+#![allow(unsafe_code)]
 use crate::internal::{unordered_load3, HashPacket, PACKET_SIZE};
 use crate::{HighwayHash, Key};
 use core::arch::aarch64::*;

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,3 +1,5 @@
+#![allow(unsafe_code)]
+
 use crate::key::Key;
 use crate::traits::HighwayHash;
 use core::{default::Default, fmt::Debug, mem::ManuallyDrop};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -158,6 +158,7 @@ RUSTFLAGS="-C target-feature=+avx2" cargo test
 #![allow(non_snake_case)]
 #![cfg_attr(all(not(feature = "std"), not(test)), no_std)]
 #![warn(missing_docs)]
+#![deny(unsafe_code)]
 
 #[macro_use]
 mod macros;

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -1,3 +1,4 @@
+#![allow(unsafe_code)]
 use crate::internal::{unordered_load3, HashPacket, PACKET_SIZE};
 use crate::{HighwayHash, Key};
 use core::arch::wasm32::{self, v128};

--- a/src/x86/avx.rs
+++ b/src/x86/avx.rs
@@ -1,3 +1,4 @@
+#![allow(unsafe_code)]
 use super::{v2x64u::V2x64U, v4x64u::V4x64U};
 use crate::internal::unordered_load3;
 use crate::internal::{HashPacket, PACKET_SIZE};

--- a/src/x86/sse.rs
+++ b/src/x86/sse.rs
@@ -1,3 +1,4 @@
+#![allow(unsafe_code)]
 use super::v2x64u::V2x64U;
 use crate::internal::unordered_load3;
 use crate::internal::{HashPacket, PACKET_SIZE};

--- a/src/x86/v2x64u.rs
+++ b/src/x86/v2x64u.rs
@@ -1,3 +1,4 @@
+#![allow(unsafe_code)]
 use core::arch::x86_64::*;
 use core::ops::{
     Add, AddAssign, BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, ShlAssign,

--- a/src/x86/v4x64u.rs
+++ b/src/x86/v4x64u.rs
@@ -1,3 +1,4 @@
+#![allow(unsafe_code)]
 use core::arch::x86_64::*;
 use core::ops::{
     Add, AddAssign, BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, SubAssign,


### PR DESCRIPTION
This should help catch any accidental introductions of unsafe into the portable implementation, which should remain unsafe free.

Implementations that rely on unsafe for platform instrinsics are marked with `allow(unsafe_code)`.