### PR TITLE
Make x86 sse implementation panic-less

### DIFF
--- a/examples/no_panic.rs
+++ b/examples/no_panic.rs
@@ -22,5 +22,9 @@ fn main() {
         if let Some(hasher) = highway::AvxHash::new(highway::Key::default()) {
             println!("{}", hash_data(hasher, &data));
         }
+
+        if let Some(hasher) = highway::SseHash::new(highway::Key::default()) {
+            println!("{}", hash_data(hasher, &data));
+        }
     }
 }


### PR DESCRIPTION
There were some bound checks in `load_multiple_of_four` that was eliminated with a `get`

Benchmarks showed up to a 10% throughput improvement for small payloads. (< 64 bytes)