### PR TITLE
Clarify the role of PortableHash

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,18 +2,16 @@
 
 # Highway-rs
 
-This crate is a native Rust port of [Google's
-HighwayHash](https://github.com/google/highwayhash), which is a fast, keyed,
-portable (output is hardware independent) and strong hash function.
+This crate is a native Rust port of [Google's HighwayHash](https://github.com/google/highwayhash), which is a fast, keyed, and strong hash function, whose output is hardware independent.
 
 ## Features
 
  - ✔ pure / stable rust
  - ✔ zero dependencies
- - ✔ generate 64, 128, and 256bit hashes
+ - ✔ generate consistent 64, 128, and 256bit hashes across all hardware
  - ✔ > 10 GB/s with SIMD (SSE 4.1 AVX 2, NEON) aware instructions on x86 and aarch64 architectures
  - ✔ > 3 GB/s on Wasm with the Wasm SIMD extension
- - ✔ > 1 GB/s portable implementation with zero unsafe code
+ - ✔ > 1 GB/s hardware agnostic implementation with zero unsafe code
  - ✔ incremental / streaming hashes
  - ✔ zero heap allocations
  - ✔ `no_std` compatible
@@ -122,6 +120,11 @@ use std::hash::Hasher;
 use highway::{PortableHash, HighwayHash};
 
 let mut file = &b"hello world"[..];
+
+// We're using the `PortableHash` to show importing a specific hashing
+// implementation (all hash outputs are already portable / hardware agnostic).
+// The main reason for directly using `PortableHash` would be if avoiding
+// `unsafe` code blocks is a top priority.
 let mut hasher = PortableHash::default();
 std::io::copy(&mut file, &mut hasher)?;
 let hash64 = hasher.finish(); // core Hasher API

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,6 @@
 /*!
 
-This crate is a native Rust port of [Google's
-HighwayHash](https://github.com/google/highwayhash), which is a fast, keyed,
-portable (output is hardware independent) and strong hash function.
+This crate is a native Rust port of [Google's HighwayHash](https://github.com/google/highwayhash), which is a fast, keyed, and strong hash function, whose output is hardware independent.
 
 ## Caution
 
@@ -116,6 +114,11 @@ use std::hash::Hasher;
 use highway::{PortableHash, HighwayHash};
 
 let mut file = &b"hello world"[..];
+
+// We're using the `PortableHash` to show importing a specific hashing
+// implementation (all hash outputs are already portable / hardware agnostic).
+// The main reason for directly using `PortableHash` would be if avoiding
+// `unsafe` code blocks is a top priority.
 let mut hasher = PortableHash::default();
 std::io::copy(&mut file, &mut hasher)?;
 let hash64 = hasher.finish(); // core Hasher API

--- a/src/portable.rs
+++ b/src/portable.rs
@@ -2,7 +2,14 @@ use crate::internal::{HashPacket, PACKET_SIZE};
 use crate::key::Key;
 use crate::traits::HighwayHash;
 
-/// Portable HighwayHash implementation. Will run on any platform Rust will run on.
+/// Hardware agnostic HighwayHash implementation.
+///
+/// "Portable" refers to being able to run on any platform Rust will run on, and
+/// is not referring to the output, as the HighwayHash is already hardware
+/// agnostic across all implementations.
+///
+/// The main reason for directly using `PortableHash` would be if avoiding
+/// `unsafe` code blocks is a top priority.
 #[derive(Debug, Default, Clone)]
 pub struct PortableHash {
     v0: [u64; 4],


### PR DESCRIPTION
The use of "portable" in the docs is playing two roles:

1. Describing that the HighwayHash output is "portable" and is not effected by the execution environment
2. Describing an implementation that is hardware agnostic: `PortableHash`

I've updated the wording in case those skimming the docs and examples misunderstood that only `PortableHash` provides a consistent output (it does, but so do all implementations).