### PR TITLE
Allow checkpointing and restoration of hash state

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This crate is a native Rust port of [Google's HighwayHash](https://github.com/go
  - ✔ > 10 GB/s with SIMD (SSE 4.1 AVX 2, NEON) aware instructions on x86 and aarch64 architectures
  - ✔ > 3 GB/s on Wasm with the Wasm SIMD extension
  - ✔ > 1 GB/s hardware agnostic implementation with zero unsafe code
- - ✔ incremental / streaming hashes
+ - ✔ incremental / streaming hashes that can be checkpointed and restored
  - ✔ zero heap allocations
  - ✔ `no_std` compatible
  - ✔ fuzzed against reference implementation to ensure stability and compatibility

--- a/examples/no_panic.rs
+++ b/examples/no_panic.rs
@@ -7,7 +7,8 @@ use std::io::Read;
 #[inline(never)]
 fn hash_data<H: HighwayHash>(mut hasher: H, data: &[u8]) -> u64 {
     hasher.append(data);
-    hasher.finalize64()
+    let snd = PortableHash::from_checkpoint(hasher.checkpoint());
+    hasher.finalize64() + snd.finalize64()
 }
 
 fn main() {

--- a/src/aarch64.rs
+++ b/src/aarch64.rs
@@ -1,6 +1,6 @@
 #![allow(unsafe_code)]
 use crate::internal::{unordered_load3, HashPacket, PACKET_SIZE};
-use crate::{HighwayHash, Key};
+use crate::{HighwayHash, Key, PortableHash};
 use core::arch::aarch64::*;
 use core::ops::{
     Add, AddAssign, BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, SubAssign,
@@ -42,10 +42,39 @@ impl HighwayHash for NeonHash {
     fn finalize256(mut self) -> [u64; 4] {
         unsafe { Self::finalize256(&mut self) }
     }
+
+    #[inline]
+    fn checkpoint(&self) -> [u8; 164] {
+        let mut v0 = [0u64; 4];
+        v0[..2].copy_from_slice(unsafe { &self.v0L.as_arr() });
+        v0[2..].copy_from_slice(unsafe { &self.v0H.as_arr() });
+
+        let mut v1 = [0u64; 4];
+        v1[..2].copy_from_slice(unsafe { &self.v1L.as_arr() });
+        v1[2..].copy_from_slice(unsafe { &self.v1H.as_arr() });
+
+        let mut mul0 = [0u64; 4];
+        mul0[..2].copy_from_slice(unsafe { &self.mul0L.as_arr() });
+        mul0[2..].copy_from_slice(unsafe { &self.mul0H.as_arr() });
+
+        let mut mul1 = [0u64; 4];
+        mul1[..2].copy_from_slice(unsafe { &self.mul1L.as_arr() });
+        mul1[2..].copy_from_slice(unsafe { &self.mul1H.as_arr() });
+
+        PortableHash {
+            v0,
+            v1,
+            mul0,
+            mul1,
+            buffer: self.buffer,
+        }
+        .checkpoint()
+    }
 }
 
 impl NeonHash {
     /// Creates a new `NeonHash` while circumventing any runtime checks.
+    #[must_use]
     pub unsafe fn force_new(key: Key) -> Self {
         let init0L = V2x64U::new(0xa409_3822_299f_31d0, 0xdbe6_d5d5_fe4c_ce2f);
         let init0H = V2x64U::new(0x243f_6a88_85a3_08d3, 0x1319_8a2e_0370_7344);
@@ -64,6 +93,23 @@ impl NeonHash {
             mul1L: init1L,
             mul1H: init1H,
             buffer: HashPacket::default(),
+        }
+    }
+
+    /// Creates a new `NeonHash` from a checkpoint
+    #[must_use]
+    pub unsafe fn force_from_checkpoint(data: [u8; 164]) -> Self {
+        let portable = PortableHash::from_checkpoint(data);
+        NeonHash {
+            v0L: V2x64U::new(portable.v0[1], portable.v0[0]),
+            v0H: V2x64U::new(portable.v0[3], portable.v0[2]),
+            v1L: V2x64U::new(portable.v1[1], portable.v1[0]),
+            v1H: V2x64U::new(portable.v1[3], portable.v1[2]),
+            mul0L: V2x64U::new(portable.mul0[1], portable.mul0[0]),
+            mul0H: V2x64U::new(portable.mul0[3], portable.mul0[2]),
+            mul1L: V2x64U::new(portable.mul1[1], portable.mul1[0]),
+            mul1H: V2x64U::new(portable.mul1[3], portable.mul1[2]),
+            buffer: portable.buffer,
         }
     }
 

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -23,7 +23,7 @@ pub const PACKET_SIZE: usize = 32;
 #[repr(C)]
 #[derive(Default, Debug, Clone, Copy)]
 pub struct HashPacket {
-    buf: [u8; PACKET_SIZE],
+    pub(crate) buf: [u8; PACKET_SIZE],
     buf_index: usize,
 }
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -35,4 +35,10 @@ pub trait HighwayHash: Sized {
 
     /// Consumes the hasher to return the 256bit hash
     fn finalize256(self) -> [u64; 4];
+
+    /// Serialize the hasher state to be persisted or resumed by another hasher
+    /// 
+    /// Note: At this time, the checkpoint format and API should be considered experimental.
+    /// The format may change in future versions.
+    fn checkpoint(&self) -> [u8; 164];
 }

--- a/src/x86/v4x64u.rs
+++ b/src/x86/v4x64u.rs
@@ -45,7 +45,7 @@ impl V4x64U {
     }
 
     #[target_feature(enable = "avx2")]
-    unsafe fn as_arr(&self) -> [u64; 4] {
+    pub unsafe fn as_arr(&self) -> [u64; 4] {
         let mut arr: [u64; 4] = [0; 4];
         _mm256_storeu_si256(arr.as_mut_ptr().cast::<__m256i>(), self.0);
         arr

--- a/tests/wasm.rs
+++ b/tests/wasm.rs
@@ -30,10 +30,15 @@ fn wasm_eq_portable() {
     ]);
 
     for i in 0..data.len() {
-        assert_eq!(
-            WasmHash::new(key).hash64(&data[..i]),
-            PortableHash::new(key).hash64(&data[..i])
-        );
+        let hash64 = PortableHash::new(key).hash64(&data[..i]);
+        assert_eq!(WasmHash::new(key).hash64(&data[..i]), hash64);
+
+        let (head, tail) = &data[..i].split_at(i / 2);
+        let mut hasher = WasmHash::new(key);
+        hasher.append(head);
+        let mut snd = WasmHash::from_checkpoint(hasher.checkpoint());
+        snd.append(tail);
+        assert_eq!(hash64, snd.finalize64());
 
         assert_eq!(
             WasmHash::new(key).hash128(&data[..i]),


### PR DESCRIPTION
If one is hashing a stream of data over a long period of time, it becomes conducive to be able to checkpoint the hash state to allow one to recover the state without rehashing the rest of the data.

It also allows great flexibility on how one wants to hash data.

I'm not tied to this exact API. Hard coding the number of bytes is potentially brittle, but it does remove any chance of a fallible write or read during serialization / deserialization. I don't see format changing for some time.

Closes #88