### PR TITLE
Add hwysum example

### DIFF
--- a/examples/hwysum.rs
+++ b/examples/hwysum.rs
@@ -1,0 +1,25 @@
+use highway::HighwayHash;
+
+// This is a simple example of how to hash data from stdin using a
+// HighwayHasher. Analagous to `shasum` and `md5sum` but using HighwayHash.
+//
+// ```bash
+// cargo run --release --example hwysum < README.md
+// ```
+#[cfg(feature = "std")]
+fn main() {
+    let stdin = std::io::stdin();
+    let mut lock = stdin.lock();
+    let mut hasher = highway::HighwayHasher::new(highway::Key::default());
+    let _ = std::io::copy(&mut lock, &mut hasher);
+    let hash = hasher.finalize256();
+    println!(
+        "{:016x}{:016x}{:016x}{:016x}",
+        hash[0], hash[1], hash[2], hash[3]
+    );
+}
+
+#[cfg(not(feature = "std"))]
+fn main() {
+    println!("This example requires the 'std' feature to be enabled.");
+}


### PR DESCRIPTION
Having a small example to do some performance investigation with cross compilation proved useful, so committing it to the repo so there is an example of how to write the highway hash version of `shasum`