### PR TITLE
Mark std as a required feature for hwysum example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,3 +36,7 @@ harness = false
 [profile.release]
 lto = "fat"
 codegen-units = 1
+
+[[example]]
+name = "hwysum"
+required-features = ["std"]

--- a/examples/hwysum.rs
+++ b/examples/hwysum.rs
@@ -6,7 +6,6 @@ use highway::HighwayHash;
 // ```bash
 // cargo run --release --example hwysum < README.md
 // ```
-#[cfg(feature = "std")]
 fn main() {
     let stdin = std::io::stdin();
     let mut lock = stdin.lock();
@@ -17,9 +16,4 @@ fn main() {
         "{:016x}{:016x}{:016x}{:016x}",
         hash[0], hash[1], hash[2], hash[3]
     );
-}
-
-#[cfg(not(feature = "std"))]
-fn main() {
-    println!("This example requires the 'std' feature to be enabled.");
 }


### PR DESCRIPTION
Bit more of a concise implementation and is now a compile time error (instead of runtime) when hwysum is compiled without std.