### PR TITLE
Add public inherent methods to hashing implementation

### DIFF
--- a/src/aarch64.rs
+++ b/src/aarch64.rs
@@ -24,23 +24,23 @@ impl HighwayHash for NeonHash {
     #[inline]
     fn append(&mut self, data: &[u8]) {
         unsafe {
-            self.append(data);
+            self.append_impl(data);
         }
     }
 
     #[inline]
     fn finalize64(mut self) -> u64 {
-        unsafe { Self::finalize64(&mut self) }
+        unsafe { self.finalize64_impl() }
     }
 
     #[inline]
     fn finalize128(mut self) -> [u64; 2] {
-        unsafe { Self::finalize128(&mut self) }
+        unsafe { self.finalize128_impl() }
     }
 
     #[inline]
     fn finalize256(mut self) -> [u64; 4] {
-        unsafe { Self::finalize256(&mut self) }
+        unsafe { self.finalize256_impl() }
     }
 
     #[inline]
@@ -73,6 +73,26 @@ impl HighwayHash for NeonHash {
 }
 
 impl NeonHash {
+    /// Adds data to be hashed
+    pub fn append(&mut self, data: &[u8]) {
+        HighwayHash::append(self, data);
+    }
+
+    /// Consumes the hasher to return the 64bit hash
+    pub fn finalize64(self) -> u64 {
+        HighwayHash::finalize64(self)
+    }
+
+    /// Consumes the hasher to return the 128bit hash
+    pub fn finalize128(self) -> [u64; 2] {
+        HighwayHash::finalize128(self)
+    }
+
+    /// Consumes the hasher to return the 256bit hash
+    pub fn finalize256(self) -> [u64; 4] {
+        HighwayHash::finalize256(self)
+    }
+
     /// Creates a new `NeonHash` while circumventing any runtime checks.
     #[must_use]
     pub unsafe fn force_new(key: Key) -> Self {
@@ -155,7 +175,7 @@ impl NeonHash {
         self.update((low, high));
     }
 
-    pub(crate) unsafe fn finalize64(&mut self) -> u64 {
+    pub(crate) unsafe fn finalize64_impl(&mut self) -> u64 {
         if !self.buffer.is_empty() {
             self.update_remainder();
         }
@@ -170,7 +190,7 @@ impl NeonHash {
         hash.as_arr()[0]
     }
 
-    pub(crate) unsafe fn finalize128(&mut self) -> [u64; 2] {
+    pub(crate) unsafe fn finalize128_impl(&mut self) -> [u64; 2] {
         if !self.buffer.is_empty() {
             self.update_remainder();
         }
@@ -185,7 +205,7 @@ impl NeonHash {
         hash.as_arr()
     }
 
-    pub(crate) unsafe fn finalize256(&mut self) -> [u64; 4] {
+    pub(crate) unsafe fn finalize256_impl(&mut self) -> [u64; 4] {
         if !self.buffer.is_empty() {
             self.update_remainder();
         }
@@ -292,7 +312,7 @@ impl NeonHash {
         (packetH, packetL)
     }
 
-    unsafe fn append(&mut self, data: &[u8]) {
+    pub(crate) unsafe fn append_impl(&mut self, data: &[u8]) {
         if self.buffer.is_empty() {
             let mut chunks = data.chunks_exact(PACKET_SIZE);
             for chunk in chunks.by_ref() {

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -117,22 +117,22 @@ impl Clone for HighwayHasher {
 impl HighwayHash for HighwayHasher {
     #[inline]
     fn append(&mut self, data: &[u8]) {
-        self.append(data);
+        self.append_impl(data);
     }
 
     #[inline]
     fn finalize64(mut self) -> u64 {
-        Self::finalize64(&mut self)
+        self.finalize64_impl()
     }
 
     #[inline]
     fn finalize128(mut self) -> [u64; 2] {
-        Self::finalize128(&mut self)
+        self.finalize128_impl()
     }
 
     #[inline]
     fn finalize256(mut self) -> [u64; 4] {
-        Self::finalize256(&mut self)
+        self.finalize256_impl()
     }
 
     #[inline]
@@ -142,6 +142,26 @@ impl HighwayHash for HighwayHasher {
 }
 
 impl HighwayHasher {
+    /// Adds data to be hashed
+    pub fn append(&mut self, data: &[u8]) {
+        HighwayHash::append(self, data);
+    }
+
+    /// Consumes the hasher to return the 64bit hash
+    pub fn finalize64(self) -> u64 {
+        HighwayHash::finalize64(self)
+    }
+
+    /// Consumes the hasher to return the 128bit hash
+    pub fn finalize128(self) -> [u64; 2] {
+        HighwayHash::finalize128(self)
+    }
+
+    /// Consumes the hasher to return the 256bit hash
+    pub fn finalize256(self) -> [u64; 4] {
+        HighwayHash::finalize256(self)
+    }
+
     /// Creates a new hasher based on compilation and runtime capabilities
     #[must_use]
     pub fn new(key: Key) -> Self {
@@ -294,78 +314,78 @@ impl HighwayHasher {
         }
     }
 
-    fn append(&mut self, data: &[u8]) {
+    fn append_impl(&mut self, data: &[u8]) {
         match self.tag {
             #[cfg(not(any(
                 all(target_family = "wasm", target_feature = "simd128"),
                 target_arch = "aarch64"
             )))]
-            0 => unsafe { &mut self.inner.portable }.append(data),
+            0 => unsafe { &mut self.inner.portable }.append_impl(data),
             #[cfg(target_arch = "x86_64")]
-            1 => unsafe { &mut self.inner.avx }.append(data),
+            1 => unsafe { (*self.inner.avx).append_impl(data) },
             #[cfg(target_arch = "x86_64")]
-            2 => unsafe { &mut self.inner.sse }.append(data),
+            2 => unsafe { (*self.inner.sse).append_impl(data) },
             #[cfg(target_arch = "aarch64")]
-            3 => unsafe { &mut self.inner.neon }.append(data),
+            3 => unsafe { (*self.inner.neon).append_impl(data) },
             #[cfg(all(target_family = "wasm", target_feature = "simd128"))]
-            4 => unsafe { &mut self.inner.wasm }.append(data),
+            4 => unsafe { &mut self.inner.wasm }.append_impl(data),
             _ => unsafe { core::hint::unreachable_unchecked() },
         }
     }
 
-    fn finalize64(&mut self) -> u64 {
+    fn finalize64_impl(&mut self) -> u64 {
         match self.tag {
             #[cfg(not(any(
                 all(target_family = "wasm", target_feature = "simd128"),
                 target_arch = "aarch64"
             )))]
-            0 => unsafe { PortableHash::finalize64(&mut self.inner.portable) },
+            0 => unsafe { PortableHash::finalize64_impl(&mut self.inner.portable) },
             #[cfg(target_arch = "x86_64")]
-            1 => unsafe { AvxHash::finalize64(&mut self.inner.avx) },
+            1 => unsafe { AvxHash::finalize64_impl(&mut self.inner.avx) },
             #[cfg(target_arch = "x86_64")]
-            2 => unsafe { SseHash::finalize64(&mut self.inner.sse) },
+            2 => unsafe { SseHash::finalize64_impl(&mut self.inner.sse) },
             #[cfg(target_arch = "aarch64")]
-            3 => unsafe { NeonHash::finalize64(&mut self.inner.neon) },
+            3 => unsafe { NeonHash::finalize64_impl(&mut self.inner.neon) },
             #[cfg(all(target_family = "wasm", target_feature = "simd128"))]
-            4 => unsafe { WasmHash::finalize64(&mut self.inner.wasm) },
+            4 => unsafe { WasmHash::finalize64_impl(&mut self.inner.wasm) },
             _ => unsafe { core::hint::unreachable_unchecked() },
         }
     }
 
-    fn finalize128(&mut self) -> [u64; 2] {
+    fn finalize128_impl(&mut self) -> [u64; 2] {
         match self.tag {
             #[cfg(not(any(
                 all(target_family = "wasm", target_feature = "simd128"),
                 target_arch = "aarch64"
             )))]
-            0 => unsafe { PortableHash::finalize128(&mut self.inner.portable) },
+            0 => unsafe { PortableHash::finalize128_impl(&mut self.inner.portable) },
             #[cfg(target_arch = "x86_64")]
-            1 => unsafe { AvxHash::finalize128(&mut self.inner.avx) },
+            1 => unsafe { AvxHash::finalize128_impl(&mut self.inner.avx) },
             #[cfg(target_arch = "x86_64")]
-            2 => unsafe { SseHash::finalize128(&mut self.inner.sse) },
+            2 => unsafe { SseHash::finalize128_impl(&mut self.inner.sse) },
             #[cfg(target_arch = "aarch64")]
-            3 => unsafe { NeonHash::finalize128(&mut self.inner.neon) },
+            3 => unsafe { NeonHash::finalize128_impl(&mut self.inner.neon) },
             #[cfg(all(target_family = "wasm", target_feature = "simd128"))]
-            4 => unsafe { WasmHash::finalize128(&mut self.inner.wasm) },
+            4 => unsafe { WasmHash::finalize128_impl(&mut self.inner.wasm) },
             _ => unsafe { core::hint::unreachable_unchecked() },
         }
     }
 
-    fn finalize256(&mut self) -> [u64; 4] {
+    fn finalize256_impl(&mut self) -> [u64; 4] {
         match self.tag {
             #[cfg(not(any(
                 all(target_family = "wasm", target_feature = "simd128"),
                 target_arch = "aarch64"
             )))]
-            0 => unsafe { PortableHash::finalize256(&mut self.inner.portable) },
+            0 => unsafe { PortableHash::finalize256_impl(&mut self.inner.portable) },
             #[cfg(target_arch = "x86_64")]
-            1 => unsafe { AvxHash::finalize256(&mut self.inner.avx) },
+            1 => unsafe { AvxHash::finalize256_impl(&mut self.inner.avx) },
             #[cfg(target_arch = "x86_64")]
-            2 => unsafe { SseHash::finalize256(&mut self.inner.sse) },
+            2 => unsafe { SseHash::finalize256_impl(&mut self.inner.sse) },
             #[cfg(target_arch = "aarch64")]
-            3 => unsafe { NeonHash::finalize256(&mut self.inner.neon) },
+            3 => unsafe { NeonHash::finalize256_impl(&mut self.inner.neon) },
             #[cfg(all(target_family = "wasm", target_feature = "simd128"))]
-            4 => unsafe { WasmHash::finalize256(&mut self.inner.wasm) },
+            4 => unsafe { WasmHash::finalize256_impl(&mut self.inner.wasm) },
             _ => unsafe { core::hint::unreachable_unchecked() },
         }
     }

--- a/src/portable.rs
+++ b/src/portable.rs
@@ -22,22 +22,22 @@ pub struct PortableHash {
 impl HighwayHash for PortableHash {
     #[inline]
     fn append(&mut self, data: &[u8]) {
-        self.append(data);
+        self.append_impl(data);
     }
 
     #[inline]
     fn finalize64(mut self) -> u64 {
-        Self::finalize64(&mut self)
+        self.finalize64_impl()
     }
 
     #[inline]
     fn finalize128(mut self) -> [u64; 2] {
-        Self::finalize128(&mut self)
+        self.finalize128_impl()
     }
 
     #[inline]
     fn finalize256(mut self) -> [u64; 4] {
-        Self::finalize256(&mut self)
+        self.finalize256_impl()
     }
 
     #[inline]
@@ -62,6 +62,26 @@ impl HighwayHash for PortableHash {
 }
 
 impl PortableHash {
+    /// Adds data to be hashed
+    pub fn append(&mut self, data: &[u8]) {
+        HighwayHash::append(self, data);
+    }
+
+    /// Consumes the hasher to return the 64bit hash
+    pub fn finalize64(self) -> u64 {
+        HighwayHash::finalize64(self)
+    }
+
+    /// Consumes the hasher to return the 128bit hash
+    pub fn finalize128(self) -> [u64; 2] {
+        HighwayHash::finalize128(self)
+    }
+
+    /// Consumes the hasher to return the 256bit hash
+    pub fn finalize256(self) -> [u64; 4] {
+        HighwayHash::finalize256(self)
+    }
+
     /// Create a new `PortableHash` from a `Key`
     #[must_use]
     pub fn new(key: Key) -> Self {
@@ -130,7 +150,7 @@ impl PortableHash {
         }
     }
 
-    pub(crate) fn finalize64(&mut self) -> u64 {
+    pub(crate) fn finalize64_impl(&mut self) -> u64 {
         if !self.buffer.is_empty() {
             self.update_remainder();
         }
@@ -145,7 +165,7 @@ impl PortableHash {
             .wrapping_add(self.mul1[0])
     }
 
-    pub(crate) fn finalize128(&mut self) -> [u64; 2] {
+    pub(crate) fn finalize128_impl(&mut self) -> [u64; 2] {
         if !self.buffer.is_empty() {
             self.update_remainder();
         }
@@ -167,7 +187,7 @@ impl PortableHash {
         [low, high]
     }
 
-    pub(crate) fn finalize256(&mut self) -> [u64; 4] {
+    pub(crate) fn finalize256_impl(&mut self) -> [u64; 4] {
         if !self.buffer.is_empty() {
             self.update_remainder();
         }
@@ -322,7 +342,7 @@ impl PortableHash {
         self.update(PortableHash::data_to_lanes(&packet));
     }
 
-    fn append(&mut self, data: &[u8]) {
+    pub(crate) fn append_impl(&mut self, data: &[u8]) {
         if self.buffer.is_empty() {
             let mut chunks = data.chunks_exact(PACKET_SIZE);
             for chunk in chunks.by_ref() {

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -23,22 +23,22 @@ pub struct WasmHash {
 impl HighwayHash for WasmHash {
     #[inline]
     fn append(&mut self, data: &[u8]) {
-        self.append(data);
+        self.append_impl(data);
     }
 
     #[inline]
     fn finalize64(mut self) -> u64 {
-        Self::finalize64(&mut self)
+        self.finalize64_impl()
     }
 
     #[inline]
     fn finalize128(mut self) -> [u64; 2] {
-        Self::finalize128(&mut self)
+        self.finalize128_impl()
     }
 
     #[inline]
     fn finalize256(mut self) -> [u64; 4] {
-        Self::finalize256(&mut self)
+        self.finalize256_impl()
     }
 
     #[inline]
@@ -71,6 +71,26 @@ impl HighwayHash for WasmHash {
 }
 
 impl WasmHash {
+    /// Adds data to be hashed
+    pub fn append(&mut self, data: &[u8]) {
+        HighwayHash::append(self, data);
+    }
+
+    /// Consumes the hasher to return the 64bit hash
+    pub fn finalize64(self) -> u64 {
+        HighwayHash::finalize64(self)
+    }
+
+    /// Consumes the hasher to return the 128bit hash
+    pub fn finalize128(self) -> [u64; 2] {
+        HighwayHash::finalize128(self)
+    }
+
+    /// Consumes the hasher to return the 256bit hash
+    pub fn finalize256(self) -> [u64; 4] {
+        HighwayHash::finalize256(self)
+    }
+
     /// Creates a new `WasmHash` based on Wasm SIMD extension
     #[must_use]
     pub fn new(key: Key) -> Self {
@@ -143,7 +163,7 @@ impl WasmHash {
         self.update((low, high));
     }
 
-    pub(crate) fn finalize64(&mut self) -> u64 {
+    pub(crate) fn finalize64_impl(&mut self) -> u64 {
         if !self.buffer.is_empty() {
             self.update_remainder();
         }
@@ -159,7 +179,7 @@ impl WasmHash {
         wasm32::u64x2_extract_lane::<1>(hash.0)
     }
 
-    pub(crate) fn finalize128(&mut self) -> [u64; 2] {
+    pub(crate) fn finalize128_impl(&mut self) -> [u64; 2] {
         if !self.buffer.is_empty() {
             self.update_remainder();
         }
@@ -177,7 +197,7 @@ impl WasmHash {
         ]
     }
 
-    pub(crate) fn finalize256(&mut self) -> [u64; 4] {
+    pub(crate) fn finalize256_impl(&mut self) -> [u64; 4] {
         if !self.buffer.is_empty() {
             self.update_remainder();
         }
@@ -301,7 +321,7 @@ impl WasmHash {
         (hi, lo)
     }
 
-    fn append(&mut self, data: &[u8]) {
+    pub(crate) fn append_impl(&mut self, data: &[u8]) {
         if self.buffer.is_empty() {
             let mut chunks = data.chunks_exact(PACKET_SIZE);
             for chunk in chunks.by_ref() {

--- a/src/x86/avx.rs
+++ b/src/x86/avx.rs
@@ -22,23 +22,23 @@ impl HighwayHash for AvxHash {
     #[inline]
     fn append(&mut self, data: &[u8]) {
         unsafe {
-            self.append(data);
+            self.append_impl(data);
         }
     }
 
     #[inline]
     fn finalize64(mut self) -> u64 {
-        unsafe { Self::finalize64(&mut self) }
+        unsafe { self.finalize64_impl() }
     }
 
     #[inline]
     fn finalize128(mut self) -> [u64; 2] {
-        unsafe { Self::finalize128(&mut self) }
+        unsafe { self.finalize128_impl() }
     }
 
     #[inline]
     fn finalize256(mut self) -> [u64; 4] {
-        unsafe { Self::finalize256(&mut self) }
+        unsafe { self.finalize256_impl() }
     }
 
     #[inline]
@@ -55,6 +55,26 @@ impl HighwayHash for AvxHash {
 }
 
 impl AvxHash {
+    /// Adds data to be hashed
+    pub fn append(&mut self, data: &[u8]) {
+        HighwayHash::append(self, data);
+    }
+
+    /// Consumes the hasher to return the 64bit hash
+    pub fn finalize64(self) -> u64 {
+        HighwayHash::finalize64(self)
+    }
+
+    /// Consumes the hasher to return the 128bit hash
+    pub fn finalize128(self) -> [u64; 2] {
+        HighwayHash::finalize128(self)
+    }
+
+    /// Consumes the hasher to return the 256bit hash
+    pub fn finalize256(self) -> [u64; 4] {
+        HighwayHash::finalize256(self)
+    }
+
     /// Creates a new `AvxHash` while circumventing the runtime check for avx2.
     ///
     /// # Safety
@@ -166,7 +186,7 @@ impl AvxHash {
     }
 
     #[target_feature(enable = "avx2")]
-    pub(crate) unsafe fn finalize64(&mut self) -> u64 {
+    pub(crate) unsafe fn finalize64_impl(&mut self) -> u64 {
         if !self.buffer.is_empty() {
             self.update_remainder();
         }
@@ -186,7 +206,7 @@ impl AvxHash {
     }
 
     #[target_feature(enable = "avx2")]
-    pub(crate) unsafe fn finalize128(&mut self) -> [u64; 2] {
+    pub(crate) unsafe fn finalize128_impl(&mut self) -> [u64; 2] {
         if !self.buffer.is_empty() {
             self.update_remainder();
         }
@@ -205,7 +225,7 @@ impl AvxHash {
     }
 
     #[target_feature(enable = "avx2")]
-    pub(crate) unsafe fn finalize256(&mut self) -> [u64; 4] {
+    pub(crate) unsafe fn finalize256_impl(&mut self) -> [u64; 4] {
         if !self.buffer.is_empty() {
             self.update_remainder();
         }
@@ -321,7 +341,7 @@ impl AvxHash {
     }
 
     #[target_feature(enable = "avx2")]
-    unsafe fn append(&mut self, data: &[u8]) {
+    pub(crate) unsafe fn append_impl(&mut self, data: &[u8]) {
         if self.buffer.is_empty() {
             let mut chunks = data.chunks_exact(PACKET_SIZE);
             for chunk in chunks.by_ref() {

--- a/src/x86/sse.rs
+++ b/src/x86/sse.rs
@@ -26,23 +26,23 @@ impl HighwayHash for SseHash {
     #[inline]
     fn append(&mut self, data: &[u8]) {
         unsafe {
-            self.append(data);
+            self.append_impl(data);
         }
     }
 
     #[inline]
     fn finalize64(mut self) -> u64 {
-        unsafe { Self::finalize64(&mut self) }
+        unsafe { self.finalize64_impl() }
     }
 
     #[inline]
     fn finalize128(mut self) -> [u64; 2] {
-        unsafe { Self::finalize128(&mut self) }
+        unsafe { self.finalize128_impl() }
     }
 
     #[inline]
     fn finalize256(mut self) -> [u64; 4] {
-        unsafe { Self::finalize256(&mut self) }
+        unsafe { self.finalize256_impl() }
     }
 
     #[inline]
@@ -75,6 +75,26 @@ impl HighwayHash for SseHash {
 }
 
 impl SseHash {
+    /// Adds data to be hashed
+    pub fn append(&mut self, data: &[u8]) {
+        HighwayHash::append(self, data);
+    }
+
+    /// Consumes the hasher to return the 64bit hash
+    pub fn finalize64(self) -> u64 {
+        HighwayHash::finalize64(self)
+    }
+
+    /// Consumes the hasher to return the 128bit hash
+    pub fn finalize128(self) -> [u64; 2] {
+        HighwayHash::finalize128(self)
+    }
+
+    /// Consumes the hasher to return the 256bit hash
+    pub fn finalize256(self) -> [u64; 4] {
+        HighwayHash::finalize256(self)
+    }
+
     /// Creates a new `SseHash` while circumventing the runtime check for sse4.1.
     ///
     /// # Safety
@@ -197,7 +217,7 @@ impl SseHash {
     }
 
     #[target_feature(enable = "sse4.1")]
-    pub(crate) unsafe fn finalize64(&mut self) -> u64 {
+    pub(crate) unsafe fn finalize64_impl(&mut self) -> u64 {
         if !self.buffer.is_empty() {
             self.update_remainder();
         }
@@ -215,7 +235,7 @@ impl SseHash {
     }
 
     #[target_feature(enable = "sse4.1")]
-    pub(crate) unsafe fn finalize128(&mut self) -> [u64; 2] {
+    pub(crate) unsafe fn finalize128_impl(&mut self) -> [u64; 2] {
         if !self.buffer.is_empty() {
             self.update_remainder();
         }
@@ -233,7 +253,7 @@ impl SseHash {
     }
 
     #[target_feature(enable = "sse4.1")]
-    pub(crate) unsafe fn finalize256(&mut self) -> [u64; 4] {
+    pub(crate) unsafe fn finalize256_impl(&mut self) -> [u64; 4] {
         if !self.buffer.is_empty() {
             self.update_remainder();
         }
@@ -347,7 +367,7 @@ impl SseHash {
     }
 
     #[target_feature(enable = "sse4.1")]
-    unsafe fn append(&mut self, data: &[u8]) {
+    pub(crate) unsafe fn append_impl(&mut self, data: &[u8]) {
         if self.buffer.is_empty() {
             let mut chunks = data.chunks_exact(PACKET_SIZE);
             for chunk in chunks.by_ref() {

--- a/tests/inherent_methods.rs
+++ b/tests/inherent_methods.rs
@@ -1,0 +1,55 @@
+use highway::{HighwayHasher, Key, PortableHash};
+
+#[test]
+fn test_highway_hasher_without_trait_import() {
+    let key = Key([1, 2, 3, 4]);
+    let mut hasher = HighwayHasher::new(key);
+
+    // These should work without importing HighwayHash trait
+    hasher.append(&[255]);
+    let res64: u64 = hasher.finalize64();
+    assert_eq!(0x07858f24d_2d79b2b2, res64);
+
+    let mut hasher128 = HighwayHasher::new(key);
+    hasher128.append(&[255]);
+    let res128: [u64; 2] = hasher128.finalize128();
+    assert_eq!([0xbb007d2462e77f3c, 0x224508f916b3991f], res128);
+
+    let mut hasher256 = HighwayHasher::new(key);
+    hasher256.append(&[255]);
+    let res256: [u64; 4] = hasher256.finalize256();
+    let expected: [u64; 4] = [
+        0x7161cadbf7cd70e1,
+        0xaac4905de62b2f5e,
+        0x7b02b936933faa7,
+        0xc8efcfc45b239f8d,
+    ];
+    assert_eq!(expected, res256);
+}
+
+#[test]
+fn test_portable_hash_without_trait_import() {
+    let key = Key([1, 2, 3, 4]);
+    let mut hasher = PortableHash::new(key);
+
+    // These should work without importing HighwayHash trait
+    hasher.append(&[255]);
+    let res64: u64 = hasher.finalize64();
+    assert_eq!(0x07858f24d_2d79b2b2, res64);
+
+    let mut hasher128 = PortableHash::new(key);
+    hasher128.append(&[255]);
+    let res128: [u64; 2] = hasher128.finalize128();
+    assert_eq!([0xbb007d2462e77f3c, 0x224508f916b3991f], res128);
+
+    let mut hasher256 = PortableHash::new(key);
+    hasher256.append(&[255]);
+    let res256: [u64; 4] = hasher256.finalize256();
+    let expected: [u64; 4] = [
+        0x7161cadbf7cd70e1,
+        0xaac4905de62b2f5e,
+        0x7b02b936933faa7,
+        0xc8efcfc45b239f8d,
+    ];
+    assert_eq!(expected, res256);
+}


### PR DESCRIPTION
When someone uses a highway hasher without importing the HighwayHash trait, they get a cryptic "private method" error because trait methods aren't available without the trait import and it happens to be that the backing implementation has the same function name.

Rust-analyzer shows unhelpful error messages and no quick fixes.

This seems less than ideal, so this commit makes implementations public so that the trait import is not needed.