### PR TITLE
Loop unroll 4x for ~10% throughput for simd

### DIFF
--- a/src/aarch64.rs
+++ b/src/aarch64.rs
@@ -1,5 +1,5 @@
 #![allow(unsafe_code)]
-use crate::internal::{unordered_load3, HashPacket, PACKET_SIZE};
+use crate::internal::{unordered_load3, HashPacket, PACKET_SIZE, UNROLL_FACTOR};
 use crate::{HighwayHash, Key, PortableHash};
 use core::arch::aarch64::*;
 use core::ops::{
@@ -304,20 +304,26 @@ impl NeonHash {
 
     unsafe fn append(&mut self, data: &[u8]) {
         if self.buffer.is_empty() {
-            let mut chunks = data.chunks_exact(PACKET_SIZE);
-            for chunk in chunks.by_ref() {
-                self.update(Self::data_to_lanes(chunk));
-            }
-            self.buffer.set_to(chunks.remainder());
+            Self::process_all(self, data);
         } else if let Some(tail) = self.buffer.fill(data) {
             self.update(Self::data_to_lanes(self.buffer.inner()));
-            let mut chunks = tail.chunks_exact(PACKET_SIZE);
-            for chunk in chunks.by_ref() {
-                self.update(Self::data_to_lanes(chunk));
-            }
-
-            self.buffer.set_to(chunks.remainder());
+            Self::process_all(self, tail);
         }
+    }
+
+    #[inline]
+    unsafe fn process_all(&mut self, data: &[u8]) {
+        let mut chunks = data.chunks_exact(PACKET_SIZE * UNROLL_FACTOR);
+        for chunk in chunks.by_ref() {
+            for packet in chunk.chunks_exact(PACKET_SIZE) {
+                self.update(Self::data_to_lanes(packet));
+            }
+        }
+        let mut single = chunks.remainder().chunks_exact(PACKET_SIZE);
+        for chunk in single.by_ref() {
+            self.update(Self::data_to_lanes(chunk));
+        }
+        self.buffer.set_to(single.remainder());
     }
 }
 

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -16,6 +16,7 @@ pub fn unordered_load3(from: &[u8]) -> u64 {
 }
 
 pub const PACKET_SIZE: usize = 32;
+pub const UNROLL_FACTOR: usize = 4;
 
 /// The c layout is needed as we'll be interpretting the buffer as different types and passing it
 /// to simd instructions, so we need to subscribe to the whole "do what C does", else we will

--- a/src/portable.rs
+++ b/src/portable.rs
@@ -1,4 +1,4 @@
-use crate::internal::{HashPacket, PACKET_SIZE};
+use crate::internal::{HashPacket, PACKET_SIZE, UNROLL_FACTOR};
 use crate::key::Key;
 use crate::traits::HighwayHash;
 
@@ -324,20 +324,26 @@ impl PortableHash {
 
     fn append(&mut self, data: &[u8]) {
         if self.buffer.is_empty() {
-            let mut chunks = data.chunks_exact(PACKET_SIZE);
-            for chunk in chunks.by_ref() {
-                self.update(Self::data_to_lanes(chunk));
-            }
-            self.buffer.set_to(chunks.remainder());
+            Self::process_all(self, data);
         } else if let Some(tail) = self.buffer.fill(data) {
             self.update(Self::data_to_lanes(self.buffer.inner()));
-            let mut chunks = tail.chunks_exact(PACKET_SIZE);
-            for chunk in chunks.by_ref() {
-                self.update(Self::data_to_lanes(chunk));
-            }
-
-            self.buffer.set_to(chunks.remainder());
+            Self::process_all(self, tail);
         }
+    }
+
+    #[inline]
+    fn process_all(&mut self, data: &[u8]) {
+        let mut chunks = data.chunks_exact(PACKET_SIZE * UNROLL_FACTOR);
+        for chunk in chunks.by_ref() {
+            for packet in chunk.chunks_exact(PACKET_SIZE) {
+                self.update(Self::data_to_lanes(packet));
+            }
+        }
+        let mut single = chunks.remainder().chunks_exact(PACKET_SIZE);
+        for chunk in single.by_ref() {
+            self.update(Self::data_to_lanes(chunk));
+        }
+        self.buffer.set_to(single.remainder());
     }
 }
 

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -1,4 +1,4 @@
-use crate::internal::{unordered_load3, HashPacket, PACKET_SIZE};
+use crate::internal::{unordered_load3, HashPacket, PACKET_SIZE, UNROLL_FACTOR};
 use crate::{HighwayHash, Key, PortableHash};
 use core::arch::wasm32::{self, v128};
 use core::ops::{
@@ -303,20 +303,26 @@ impl WasmHash {
 
     fn append(&mut self, data: &[u8]) {
         if self.buffer.is_empty() {
-            let mut chunks = data.chunks_exact(PACKET_SIZE);
-            for chunk in chunks.by_ref() {
-                self.update(Self::data_to_lanes(chunk));
-            }
-            self.buffer.set_to(chunks.remainder());
+            Self::process_all(self, data);
         } else if let Some(tail) = self.buffer.fill(data) {
             self.update(Self::data_to_lanes(self.buffer.inner()));
-            let mut chunks = tail.chunks_exact(PACKET_SIZE);
-            for chunk in chunks.by_ref() {
-                self.update(Self::data_to_lanes(chunk));
-            }
-
-            self.buffer.set_to(chunks.remainder());
+            Self::process_all(self, tail);
         }
+    }
+
+    #[inline]
+    fn process_all(&mut self, data: &[u8]) {
+        let mut chunks = data.chunks_exact(PACKET_SIZE * UNROLL_FACTOR);
+        for chunk in chunks.by_ref() {
+            for packet in chunk.chunks_exact(PACKET_SIZE) {
+                self.update(Self::data_to_lanes(packet));
+            }
+        }
+        let mut single = chunks.remainder().chunks_exact(PACKET_SIZE);
+        for chunk in single.by_ref() {
+            self.update(Self::data_to_lanes(chunk));
+        }
+        self.buffer.set_to(single.remainder());
     }
 }
 

--- a/src/x86/avx.rs
+++ b/src/x86/avx.rs
@@ -1,6 +1,6 @@
 #![allow(unsafe_code)]
 use super::{v2x64u::V2x64U, v4x64u::V4x64U};
-use crate::internal::unordered_load3;
+use crate::internal::{unordered_load3, UNROLL_FACTOR};
 use crate::internal::{HashPacket, PACKET_SIZE};
 use crate::key::Key;
 use crate::traits::HighwayHash;
@@ -323,20 +323,27 @@ impl AvxHash {
     #[target_feature(enable = "avx2")]
     unsafe fn append(&mut self, data: &[u8]) {
         if self.buffer.is_empty() {
-            let mut chunks = data.chunks_exact(PACKET_SIZE);
-            for chunk in chunks.by_ref() {
-                self.update(Self::data_to_lanes(chunk));
-            }
-            self.buffer.set_to(chunks.remainder());
+            Self::process_all(self, data);
         } else if let Some(tail) = self.buffer.fill(data) {
             self.update(Self::data_to_lanes(self.buffer.inner()));
-            let mut chunks = tail.chunks_exact(PACKET_SIZE);
-            for chunk in chunks.by_ref() {
-                self.update(Self::data_to_lanes(chunk));
-            }
-
-            self.buffer.set_to(chunks.remainder());
+            Self::process_all(self, tail);
         }
+    }
+
+    #[inline]
+    #[target_feature(enable = "avx2")]
+    unsafe fn process_all(&mut self, data: &[u8]) {
+        let mut chunks = data.chunks_exact(PACKET_SIZE * UNROLL_FACTOR);
+        for chunk in chunks.by_ref() {
+            for packet in chunk.chunks_exact(PACKET_SIZE) {
+                self.update(Self::data_to_lanes(packet));
+            }
+        }
+        let mut single = chunks.remainder().chunks_exact(PACKET_SIZE);
+        for chunk in single.by_ref() {
+            self.update(Self::data_to_lanes(chunk));
+        }
+        self.buffer.set_to(single.remainder());
     }
 }
 

--- a/src/x86/sse.rs
+++ b/src/x86/sse.rs
@@ -1,7 +1,7 @@
 #![allow(unsafe_code)]
 use super::v2x64u::V2x64U;
 use crate::internal::unordered_load3;
-use crate::internal::{HashPacket, PACKET_SIZE};
+use crate::internal::{HashPacket, PACKET_SIZE, UNROLL_FACTOR};
 use crate::key::Key;
 use crate::traits::HighwayHash;
 use crate::PortableHash;
@@ -349,20 +349,27 @@ impl SseHash {
     #[target_feature(enable = "sse4.1")]
     unsafe fn append(&mut self, data: &[u8]) {
         if self.buffer.is_empty() {
-            let mut chunks = data.chunks_exact(PACKET_SIZE);
-            for chunk in chunks.by_ref() {
-                self.update(Self::data_to_lanes(chunk));
-            }
-            self.buffer.set_to(chunks.remainder());
+            Self::process_all(self, data);
         } else if let Some(tail) = self.buffer.fill(data) {
             self.update(Self::data_to_lanes(self.buffer.inner()));
-            let mut chunks = tail.chunks_exact(PACKET_SIZE);
-            for chunk in chunks.by_ref() {
-                self.update(Self::data_to_lanes(chunk));
-            }
-
-            self.buffer.set_to(chunks.remainder());
+            Self::process_all(self, tail);
         }
+    }
+
+    #[inline]
+    #[target_feature(enable = "sse4.1")]
+    unsafe fn process_all(&mut self, data: &[u8]) {
+        let mut chunks = data.chunks_exact(PACKET_SIZE * UNROLL_FACTOR);
+        for chunk in chunks.by_ref() {
+            for packet in chunk.chunks_exact(PACKET_SIZE) {
+                self.update(Self::data_to_lanes(packet));
+            }
+        }
+        let mut single = chunks.remainder().chunks_exact(PACKET_SIZE);
+        for chunk in single.by_ref() {
+            self.update(Self::data_to_lanes(chunk));
+        }
+        self.buffer.set_to(single.remainder());
     }
 }
 


### PR DESCRIPTION
By unrolling 4x, data is processed in 128 byte chunks instead of 32 bytes, which improved throughput by ~10% for simd implementations.